### PR TITLE
Fix dropdown positioning & 6 theme bugs (v1.3.1 + v1.3.2)

### DIFF
--- a/themes/Frosted Glass Dark Lite.yaml
+++ b/themes/Frosted Glass Dark Lite.yaml
@@ -1,5 +1,5 @@
 # Frosted Glass Dark Lite
-# ver. 1.3.1 - (2026-02-23) 
+# ver. 1.3.2 - (2026-02-23) 
 
 Frosted Glass Dark Lite:
   card-mod-theme: 'Frosted Glass Dark Lite'

--- a/themes/Frosted Glass Dark Lite.yaml
+++ b/themes/Frosted Glass Dark Lite.yaml
@@ -1,5 +1,5 @@
 # Frosted Glass Dark Lite
-# ver. 1.3.2 - (2026-02-23) 
+# ver. 1.3.3 - (2026-02-28) 
 
 Frosted Glass Dark Lite:
   card-mod-theme: 'Frosted Glass Dark Lite'

--- a/themes/Frosted Glass Dark Lite.yaml
+++ b/themes/Frosted Glass Dark Lite.yaml
@@ -1,5 +1,5 @@
 # Frosted Glass Dark Lite
-# ver. 1.3.3 - (2026-02-28) 
+# ver. 1.3.4 - (2026-02-28)
 
 Frosted Glass Dark Lite:
   card-mod-theme: 'Frosted Glass Dark Lite'

--- a/themes/Frosted Glass Dark Lite.yaml
+++ b/themes/Frosted Glass Dark Lite.yaml
@@ -1,5 +1,5 @@
 # Frosted Glass Dark Lite
-# ver. 1.3 - (2025-11-24) 
+# ver. 1.3.1 - (2026-02-23) 
 
 Frosted Glass Dark Lite:
   card-mod-theme: 'Frosted Glass Dark Lite'
@@ -134,9 +134,9 @@ Frosted Glass Dark Lite:
       --ha-card-border-width: 0.5px;
       --ha-card-border-color: rgba(234, 235, 238, 0.1);
 
-      /* Glass system tokens (new, dark-tuned) */
-      --ha-card-glass-tint: rgba(28, 29, 33, 0.18);                                      # 1.2 Glass – global tint layer
-      --ha-card-glass-inset-shadow:                                                      # 1.2 Glass – inner bevel/glow (Liquid Glass inspired)
+      /* Glass system tokens (dark-tuned) */
+      --ha-card-glass-tint: rgba(28, 29, 33, 0.18);
+      --ha-card-glass-inset-shadow:
         3px 3px 0.5px -3.5px rgba(255, 255, 255, 0.15) inset,
         -2px -2px 0.5px -2px rgba(255, 255, 255, 0.1) inset,
         0 0 8px 1px rgba(255, 255, 255, 0.06) inset,
@@ -235,7 +235,7 @@ Frosted Glass Dark Lite:
       --token-font-family-primary: -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
       --token-weight-font-title-card: 500;
       
-      # Additional color variables
+      /* Additional color variables */
       --token-color-red: rgb(var(--token-rgb-red));
       --token-color-green: rgb(var(--token-rgb-green));
       --token-color-blue: rgb(var(--token-rgb-blue));
@@ -255,6 +255,55 @@ Frosted Glass Dark Lite:
       --token-color-indigo: rgb(var(--token-rgb-indigo));
       --token-color-deep-purple: rgb(var(--token-rgb-deep-purple));
       --token-color-light-blue: rgb(var(--token-rgb-light-blue));
+    }
+
+    /* SIDEBAR */
+    .mdc-drawer .mdc-drawer__content {
+      background: rgba(25, 28, 45, 0.8) !important;
+      box-shadow: var(--ha-card-glass-inset-shadow) !important;
+    }
+
+    /* CARDS RADIUS */
+    ha-card {
+      border-radius: var(--token-size-radius-large);
+      border: var(--ha-card-border, var(--ha-card-border-width) solid var(--ha-card-border-color));
+      box-shadow: var(--ha-card-box-shadow);
+    }
+    ha-card ha-card {
+      --ha-card-border-width: 0px;
+    }
+
+    /* DRAWER SCRIM */
+    ha-drawer {
+      --mdc-drawer-scrim-color: rgba(0, 0, 0, 0.8) !important;
+    }
+
+    /* LABEL BADGE */
+    ha-label-badge {
+      --label-badge-background-color: rgba(60, 60, 78, 0.28) !important;
+      --label-badge-text-color: rgba(234, 235, 238, 0.9) !important;
+      box-shadow: 0 5px 10px rgba(0, 0, 0, 0.10) !important;
+      border: 0.5px solid rgba(234, 235, 238, 0.22) !important;
+    }
+
+    /* INPUTS */
+    input, ha-textfield, ha-select {
+      background: rgba(30, 33, 54, 0.7) !important;
+      border-radius: var(--token-size-radius-small);
+      border: none !important;
+      box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.09) !important;
+    }
+
+    /* Custom text divider row size fix */
+    custom-text-divider-row .text-divider-content {
+      background: #181929 !important;
+      opacity: 1 !important;
+      box-shadow: none !important;
+      border-radius: 10px !important;
+      padding: 0 8px !important;
+      --text-divider-font-size: 16px !important;
+      --text-divider-line-size: 1px;
+      --text-divider-color: rgba(234, 235, 238, 1) !important;
     }
 
   # =========================
@@ -388,8 +437,8 @@ Frosted Glass Dark Lite:
   paper-toggle-button-checked-bar-color: 'rgb(106, 116, 211)'
   paper-toggle-button-unchecked-button-color: 'rgba(234, 235, 238, 0.3)'
   paper-toggle-button-unchecked-bar-color: 'rgba(234, 235, 238, 0.18)'
-  mdc-checkbox-unchecked-color: 'rgba(19, 21, 54, 0.75)'
-  mdc-radio-unchecked-color: 'rgba(19, 21, 54, 0.75)'
+  mdc-checkbox-unchecked-color: 'rgba(234, 235, 238, 0.75)'
+  mdc-radio-unchecked-color: 'rgba(234, 235, 238, 0.75)'
   mdc-ripple-hover-opacity: '0.1'
 
   # Inputs

--- a/themes/Frosted Glass Dark Lite.yaml
+++ b/themes/Frosted Glass Dark Lite.yaml
@@ -1,5 +1,5 @@
 # Frosted Glass Dark Lite
-# ver. 1.3.5 - (2026-02-28)
+# ver. 1.3.6 - (2026-02-28)
 
 Frosted Glass Dark Lite:
   card-mod-theme: 'Frosted Glass Dark Lite'

--- a/themes/Frosted Glass Dark Lite.yaml
+++ b/themes/Frosted Glass Dark Lite.yaml
@@ -1,5 +1,5 @@
 # Frosted Glass Dark Lite
-# ver. 1.3.4 - (2026-02-28)
+# ver. 1.3.5 - (2026-02-28)
 
 Frosted Glass Dark Lite:
   card-mod-theme: 'Frosted Glass Dark Lite'

--- a/themes/Frosted Glass Dark.yaml
+++ b/themes/Frosted Glass Dark.yaml
@@ -1,5 +1,5 @@
 # Frosted Glass Dark
-# ver. 1.3 - (2025-11-24) 
+# ver. 1.3.1 - (2026-02-23) 
 
 Frosted Glass Dark:
   card-mod-theme: 'Frosted Glass Dark'
@@ -154,11 +154,11 @@ Frosted Glass Dark:
       --ha-card-box-shadow: 0 12px 20px rgba(0, 0, 0, 0.28);
       --ha-card-border-width: 0.5px;
       --ha-card-border-color: rgba(234, 235, 238, 0.1);
-      --ha-card-backdrop-filter: blur(10px) saturate(1.2);                               # 1.2 Glass – same engine as Light, tuned for Dark
+      --ha-card-backdrop-filter: blur(10px) saturate(1.2);
 
-      /* Glass system tokens (new, dark-tuned) */
-      --ha-card-glass-tint: rgba(28, 29, 33, 0.18);                                      # 1.2 Glass – global tint layer
-      --ha-card-glass-inset-shadow:                                                      # 1.2 Glass – inner bevel/glow (Liquid Glass inspired)
+      /* Glass system tokens (dark-tuned) */
+      --ha-card-glass-tint: rgba(28, 29, 33, 0.18);
+      --ha-card-glass-inset-shadow:
         3px 3px 0.5px -3.5px rgba(255, 255, 255, 0.15) inset,
         -2px -2px 0.5px -2px rgba(255, 255, 255, 0.1) inset,
         0 0 8px 1px rgba(255, 255, 255, 0.06) inset,
@@ -257,7 +257,7 @@ Frosted Glass Dark:
       --token-font-family-primary: -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
       --token-weight-font-title-card: 500;
       
-      # Additional color variables
+      /* Additional color variables */
       --token-color-red: rgb(var(--token-rgb-red));
       --token-color-green: rgb(var(--token-rgb-green));
       --token-color-blue: rgb(var(--token-rgb-blue));
@@ -284,13 +284,13 @@ Frosted Glass Dark:
       backdrop-filter: blur(8px) saturate(1.1) !important;
       -webkit-backdrop-filter: blur(8px) saturate(1.1) !important;
       background: rgba(25, 28, 45, 0.8) !important;
-      box-shadow: var(--ha-card-glass-inset-shadow) !important;                         # 1.2 Glass – subtle inner edge for consistency
+      box-shadow: var(--ha-card-glass-inset-shadow) !important;
     }
 
     /* CARDS RADIUS */
     ha-card {
       border-radius: var(--token-size-radius-large);
-      border: var(--ha-card-border, var(--ha-card-border-width) solid var(--ha-card-border-color));       # 1.2 Glass – ensure border follows tokens
+      border: var(--ha-card-border, var(--ha-card-border-width) solid var(--ha-card-border-color));
       box-shadow: var(--ha-card-box-shadow);
     }
     ha-card ha-card {
@@ -313,13 +313,30 @@ Frosted Glass Dark:
     }
 
     /* INPUTS */
-    input, ha-textfield, ha-select {
+    input, ha-textfield {
       background: rgba(30, 33, 54, 0.7) !important;
       backdrop-filter: blur(6px) !important;
-      -webkit-backdrop-filter: blur(6px);
+      -webkit-backdrop-filter: blur(6px) !important;
       border-radius: var(--token-size-radius-small);
       border: none !important;
       box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.09) !important;
+    }
+    ha-select {
+      background: rgba(30, 33, 54, 0.7) !important;
+      border-radius: var(--token-size-radius-small);
+      border: none !important;
+      box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.09) !important;
+      position: relative;
+    }
+    ha-select::before {
+      content: '';
+      position: absolute;
+      inset: 0;
+      backdrop-filter: blur(6px);
+      -webkit-backdrop-filter: blur(6px);
+      border-radius: inherit;
+      z-index: -1;
+      pointer-events: none;
     }
 
     /* Custom text divider row size fix */

--- a/themes/Frosted Glass Dark.yaml
+++ b/themes/Frosted Glass Dark.yaml
@@ -1,5 +1,5 @@
 # Frosted Glass Dark
-# ver. 1.3.5 - (2026-02-28)
+# ver. 1.3.6 - (2026-02-28)
 
 Frosted Glass Dark:
   card-mod-theme: 'Frosted Glass Dark'

--- a/themes/Frosted Glass Dark.yaml
+++ b/themes/Frosted Glass Dark.yaml
@@ -10,7 +10,8 @@ Frosted Glass Dark:
   # =========================
   # HEADER (Top Bar)
   # =========================
-  app-header-background-color: 'rgba(30, 30, 30, 0.85)'
+  app-header-backdrop-filter: 'blur(8px) saturate(1.1)'
+  app-header-background-color: 'rgba(30, 30, 30, 0.01)'
   app-header-text-color: 'rgba(240, 243, 255, 0.95)'
   app-header-edit-background-color: 'rgba(30, 33, 54, 0.8)'
   app-header-edit-text-color: 'rgba(234, 235, 238, 0.98)'

--- a/themes/Frosted Glass Dark.yaml
+++ b/themes/Frosted Glass Dark.yaml
@@ -1,5 +1,5 @@
 # Frosted Glass Dark
-# ver. 1.3.1 - (2026-02-23) 
+# ver. 1.3.2 - (2026-02-23) 
 
 Frosted Glass Dark:
   card-mod-theme: 'Frosted Glass Dark'
@@ -10,8 +10,7 @@ Frosted Glass Dark:
   # =========================
   # HEADER (Top Bar)
   # =========================
-  app-header-backdrop-filter: 'blur(8px) saturate(1.1)'
-  app-header-background-color: 'rgba(30, 30, 30, 0.01)'
+  app-header-background-color: 'rgba(30, 30, 30, 0.85)'
   app-header-text-color: 'rgba(240, 243, 255, 0.95)'
   app-header-edit-background-color: 'rgba(30, 33, 54, 0.8)'
   app-header-edit-text-color: 'rgba(234, 235, 238, 0.98)'
@@ -29,8 +28,7 @@ Frosted Glass Dark:
   # =========================
   # DIALOGS
   # =========================
-  ha-dialog-surface-backdrop-filter: 'blur(8px)'                  # 1.2 Glass – same blur as cards
-  ha-dialog-surface-background: 'rgba(30, 30, 30, 0.7)'
+  ha-dialog-surface-background: 'rgba(30, 30, 30, 0.92)'
   dialog-box-shadow: '0 12px 20px rgba(0, 0, 0, 0.25)'
   paper-dialog-background-color: 'rgba(30, 30, 30, 0.7)'
   mdc-dialog-scrim-color: 'rgba(0, 0, 0, 0.8)'
@@ -279,11 +277,9 @@ Frosted Glass Dark:
       --token-color-light-blue: rgb(var(--token-rgb-light-blue));
     }
 
-    /* SIDEBAR BLUR */
+    /* SIDEBAR */
     .mdc-drawer .mdc-drawer__content {
-      backdrop-filter: blur(8px) saturate(1.1) !important;
-      -webkit-backdrop-filter: blur(8px) saturate(1.1) !important;
-      background: rgba(25, 28, 45, 0.8) !important;
+      background: rgba(25, 28, 45, 0.9) !important;
       box-shadow: var(--ha-card-glass-inset-shadow) !important;
     }
 
@@ -304,39 +300,18 @@ Frosted Glass Dark:
 
     /* LABEL BADGE */
     ha-label-badge {
-      --label-badge-background-color: rgba(60, 60, 78, 0.28) !important;
-      backdrop-filter: blur(10px) saturate(1.1) !important;
-      -webkit-backdrop-filter: blur(10px) saturate(1.1) !important;
+      --label-badge-background-color: rgba(60, 60, 78, 0.85) !important;
       --label-badge-text-color: rgba(234, 235, 238, 0.9) !important;
       box-shadow: 0 5px 10px rgba(0, 0, 0, 0.10) !important;
       border: 0.5px solid rgba(234, 235, 238, 0.22) !important;
     }
 
     /* INPUTS */
-    input, ha-textfield {
-      background: rgba(30, 33, 54, 0.7) !important;
-      backdrop-filter: blur(6px) !important;
-      -webkit-backdrop-filter: blur(6px) !important;
-      border-radius: var(--token-size-radius-small);
-      border: none !important;
-      box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.09) !important;
-    }
-    ha-select {
+    input, ha-textfield, ha-select {
       background: rgba(30, 33, 54, 0.7) !important;
       border-radius: var(--token-size-radius-small);
       border: none !important;
       box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.09) !important;
-      position: relative;
-    }
-    ha-select::before {
-      content: '';
-      position: absolute;
-      inset: 0;
-      backdrop-filter: blur(6px);
-      -webkit-backdrop-filter: blur(6px);
-      border-radius: inherit;
-      z-index: -1;
-      pointer-events: none;
     }
 
     /* Custom text divider row size fix */

--- a/themes/Frosted Glass Dark.yaml
+++ b/themes/Frosted Glass Dark.yaml
@@ -10,8 +10,7 @@ Frosted Glass Dark:
   # =========================
   # HEADER (Top Bar)
   # =========================
-  app-header-backdrop-filter: 'blur(8px) saturate(1.1)'
-  app-header-background-color: 'rgba(30, 30, 30, 0.01)'
+  app-header-background-color: 'rgba(30, 30, 30, 0.85)'
   app-header-text-color: 'rgba(240, 243, 255, 0.95)'
   app-header-edit-background-color: 'rgba(30, 33, 54, 0.8)'
   app-header-edit-text-color: 'rgba(234, 235, 238, 0.98)'

--- a/themes/Frosted Glass Dark.yaml
+++ b/themes/Frosted Glass Dark.yaml
@@ -1,5 +1,5 @@
 # Frosted Glass Dark
-# ver. 1.3.2 - (2026-02-23) 
+# ver. 1.3.3 - (2026-02-28) 
 
 Frosted Glass Dark:
   card-mod-theme: 'Frosted Glass Dark'

--- a/themes/Frosted Glass Dark.yaml
+++ b/themes/Frosted Glass Dark.yaml
@@ -1,5 +1,5 @@
 # Frosted Glass Dark
-# ver. 1.3.3 - (2026-02-28) 
+# ver. 1.3.4 - (2026-02-28)
 
 Frosted Glass Dark:
   card-mod-theme: 'Frosted Glass Dark'

--- a/themes/Frosted Glass Dark.yaml
+++ b/themes/Frosted Glass Dark.yaml
@@ -1,5 +1,5 @@
 # Frosted Glass Dark
-# ver. 1.3.4 - (2026-02-28)
+# ver. 1.3.5 - (2026-02-28)
 
 Frosted Glass Dark:
   card-mod-theme: 'Frosted Glass Dark'

--- a/themes/Frosted Glass Light Lite.yaml
+++ b/themes/Frosted Glass Light Lite.yaml
@@ -1,5 +1,5 @@
 # Frosted Glass Light Lite
-# ver. 1.3.2 - (2026-02-23)  
+# ver. 1.3.3 - (2026-02-28)  
 
 Frosted Glass Light Lite:
   card-mod-theme: "Frosted Glass Light Lite"

--- a/themes/Frosted Glass Light Lite.yaml
+++ b/themes/Frosted Glass Light Lite.yaml
@@ -1,5 +1,5 @@
 # Frosted Glass Light Lite
-# ver. 1.3 - (2025-11-24)  
+# ver. 1.3.1 - (2026-02-23)  
 
 Frosted Glass Light Lite:
   card-mod-theme: "Frosted Glass Light Lite"
@@ -135,29 +135,15 @@ Frosted Glass Light Lite:
     --ha-card-border-color: rgba(255, 255, 255, 0.3);
 
     /* Glass system tokens (new) */
-    --ha-card-glass-tint: rgba(255, 255, 255, 0.08);                                                      # 1.2 Glass – global tint layer
-    --ha-card-glass-inset-shadow:                                                                         # 1.2 Glass – inner bevel/glow (Liquid Glass inspired)
+    --ha-card-glass-tint: rgba(255, 255, 255, 0.08);                                                      /* 1.2 Glass – global tint layer */
+    --ha-card-glass-inset-shadow:                                                                         /* 1.2 Glass – inner bevel/glow (Liquid Glass inspired) */
       3px 3px 0.5px -3.5px rgba(255, 255, 255, 0.30) inset,
       -2px -2px 0.5px -2px rgba(255, 255, 255, 0.30) inset,
       0 0 8px 1px rgba(255, 255, 255, 0.10) inset,
       0 0 2px 0 rgba(0, 0, 0, 0.10);
-   }
 
-   /* Custom text divider row size fix */
-   custom-text-divider-row .text-divider-content {
-    background: #fff !important; /* or your color */
-    opacity: 1 !important;
-    box-shadow: none !important;
-    border-radius: 10px !important; /* adjust as needed */
-    padding: 0 8px !important;
-    --text-divider-font-size: 16px !important;
-    --text-divider-line-size: 1px;
-    --text-divider-color: rgba(19, 21, 54, 1) !important;
-   }
-
-    
-      # Tokens (used throughout cards/UI)
-      --token-rgb-primary: 106, 116, 211;
+    /* Tokens (used throughout cards/UI) */
+    --token-rgb-primary: 106, 116, 211;
       --token-rgb-black: 0, 0, 0;
       --token-rgb-white: 240, 243, 255;
       --token-rgb-purple: 129, 45, 250;
@@ -249,7 +235,7 @@ Frosted Glass Light Lite:
       --token-font-family-primary: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
       --token-weight-font-title-card: 500;
 
-      # Additional color variables
+      /* Additional color variables */
       --token-color-red: rgb(var(--token-rgb-red));
       --token-color-green: rgb(var(--token-rgb-green));
       --token-color-blue: rgb(var(--token-rgb-blue));
@@ -269,9 +255,21 @@ Frosted Glass Light Lite:
       --token-color-indigo: rgb(var(--token-rgb-indigo));
       --token-color-deep-purple: rgb(var(--token-rgb-deep-purple));
       --token-color-light-blue: rgb(var(--token-rgb-light-blue));
-    }
+   }
 
-    /* SIDEBAR BLUR */
+   /* Custom text divider row size fix */
+   custom-text-divider-row .text-divider-content {
+    background: #fff !important;
+    opacity: 1 !important;
+    box-shadow: none !important;
+    border-radius: 10px !important;
+    padding: 0 8px !important;
+    --text-divider-font-size: 16px !important;
+    --text-divider-line-size: 1px;
+    --text-divider-color: rgba(19, 21, 54, 1) !important;
+   }
+
+    /* SIDEBAR */
     .mdc-drawer .mdc-drawer__content {
       background: rgba(234, 235, 238, 0.7) !important;
       box-shadow: var(--ha-card-glass-inset-shadow) !important;                                          /* 1.2 Glass – subtle inner edge for consistency */
@@ -470,7 +468,7 @@ Frosted Glass Light Lite:
   mush-title-font-weight: '500'
   mush-title-font-size: 'var(--token-size-font-2xl)'
   light-grey-color: 'rgb(103, 104, 119)'
-  mush-rgb-grey: '103, 104, 119)'
+  mush-rgb-grey: '103, 104, 119'
 
   # Misc sizes
   paper-slider-height: '5px'

--- a/themes/Frosted Glass Light Lite.yaml
+++ b/themes/Frosted Glass Light Lite.yaml
@@ -1,5 +1,5 @@
 # Frosted Glass Light Lite
-# ver. 1.3.4 - (2026-02-28)
+# ver. 1.3.5 - (2026-02-28)
 
 Frosted Glass Light Lite:
   card-mod-theme: "Frosted Glass Light Lite"

--- a/themes/Frosted Glass Light Lite.yaml
+++ b/themes/Frosted Glass Light Lite.yaml
@@ -1,5 +1,5 @@
 # Frosted Glass Light Lite
-# ver. 1.3.1 - (2026-02-23)  
+# ver. 1.3.2 - (2026-02-23)  
 
 Frosted Glass Light Lite:
   card-mod-theme: "Frosted Glass Light Lite"

--- a/themes/Frosted Glass Light Lite.yaml
+++ b/themes/Frosted Glass Light Lite.yaml
@@ -1,5 +1,5 @@
 # Frosted Glass Light Lite
-# ver. 1.3.3 - (2026-02-28)  
+# ver. 1.3.4 - (2026-02-28)
 
 Frosted Glass Light Lite:
   card-mod-theme: "Frosted Glass Light Lite"

--- a/themes/Frosted Glass Light Lite.yaml
+++ b/themes/Frosted Glass Light Lite.yaml
@@ -1,5 +1,5 @@
 # Frosted Glass Light Lite
-# ver. 1.3.5 - (2026-02-28)
+# ver. 1.3.6 - (2026-02-28)
 
 Frosted Glass Light Lite:
   card-mod-theme: "Frosted Glass Light Lite"

--- a/themes/Frosted Glass Light.yaml
+++ b/themes/Frosted Glass Light.yaml
@@ -1,5 +1,5 @@
 # Frosted Glass Light
-# ver. 1.3 - (2025-11-24)  
+# ver. 1.3.1 - (2026-02-23)  
 
 Frosted Glass Light:
   card-mod-theme: "Frosted Glass Light"
@@ -155,32 +155,18 @@ Frosted Glass Light:
     --ha-card-box-shadow: 0 12px 20px rgba(0, 0, 0, 0.15);
     --ha-card-border-width: 0.5px;
     --ha-card-border-color: rgba(255, 255, 255, 0.3);
-    --ha-card-backdrop-filter: blur(8px) saturate(1.2);                                                   # 1.1.9 change - added blur & saturation for badges
+    --ha-card-backdrop-filter: blur(8px) saturate(1.2);
 
-    /* Glass system tokens (new) */
-    --ha-card-glass-tint: rgba(255, 255, 255, 0.08);                                                      # 1.2 Glass – global tint layer
-    --ha-card-glass-inset-shadow:                                                                         # 1.2 Glass – inner bevel/glow (Liquid Glass inspired)
+    /* Glass system tokens */
+    --ha-card-glass-tint: rgba(255, 255, 255, 0.08);
+    --ha-card-glass-inset-shadow:
       3px 3px 0.5px -3.5px rgba(255, 255, 255, 0.30) inset,
       -2px -2px 0.5px -2px rgba(255, 255, 255, 0.30) inset,
       0 0 8px 1px rgba(255, 255, 255, 0.10) inset,
       0 0 2px 0 rgba(0, 0, 0, 0.10);
-   }
 
-   /* Custom text divider row size fix */
-   custom-text-divider-row .text-divider-content {
-    background: #fff !important; /* or your color */
-    opacity: 1 !important;
-    box-shadow: none !important;
-    border-radius: 10px !important; /* adjust as needed */
-    padding: 0 8px !important;
-    --text-divider-font-size: 16px !important;
-    --text-divider-line-size: 1px;
-    --text-divider-color: rgba(19, 21, 54, 1) !important;
-   }
-
-    
-      # Tokens (used throughout cards/UI)
-      --token-rgb-primary: 106, 116, 211;
+    /* Tokens (used throughout cards/UI) */
+    --token-rgb-primary: 106, 116, 211;
       --token-rgb-black: 0, 0, 0;
       --token-rgb-white: 240, 243, 255;
       --token-rgb-purple: 129, 45, 250;
@@ -272,8 +258,8 @@ Frosted Glass Light:
       --token-font-family-primary: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
       --token-weight-font-title-card: 500;
 
-      # Additional color variables
-      --token-color-red: rgb(var(--token-rgb-red));
+    /* Additional color variables */
+    --token-color-red: rgb(var(--token-rgb-red));
       --token-color-green: rgb(var(--token-rgb-green));
       --token-color-blue: rgb(var(--token-rgb-blue));
       --token-color-yellow: rgb(var(--token-rgb-yellow));
@@ -291,21 +277,33 @@ Frosted Glass Light:
       --token-color-blue-grey: rgb(var(--token-rgb-blue-grey));
       --token-color-indigo: rgb(var(--token-rgb-indigo));
       --token-color-deep-purple: rgb(var(--token-rgb-deep-purple));
-      --token-color-light-blue: rgb(var(--token-rgb-light-blue));
-    }
+    --token-color-light-blue: rgb(var(--token-rgb-light-blue));
+   }
+
+   /* Custom text divider row size fix */
+   custom-text-divider-row .text-divider-content {
+    background: #fff !important;
+    opacity: 1 !important;
+    box-shadow: none !important;
+    border-radius: 10px !important;
+    padding: 0 8px !important;
+    --text-divider-font-size: 16px !important;
+    --text-divider-line-size: 1px;
+    --text-divider-color: rgba(19, 21, 54, 1) !important;
+   }
 
     /* SIDEBAR BLUR */
     .mdc-drawer .mdc-drawer__content {
       backdrop-filter: blur(6px) saturate(1.2) !important;
       -webkit-backdrop-filter: blur(6px) saturate(1.2) !important;
       background: rgba(234, 235, 238, 0.7) !important;
-      box-shadow: var(--ha-card-glass-inset-shadow) !important;                                          /* 1.2 Glass – subtle inner edge for consistency */
+      box-shadow: var(--ha-card-glass-inset-shadow) !important;
     }
 
     /* CARDS RADIUS */
     ha-card {
       border-radius: var(--token-size-radius-large);
-      border: var(--ha-card-border, var(--ha-card-border-width) solid var(--ha-card-border-color));       /* 1.2 Glass – ensure border follows tokens */
+      border: var(--ha-card-border, var(--ha-card-border-width) solid var(--ha-card-border-color));
       box-shadow: var(--ha-card-box-shadow);
     }
     ha-card ha-card {
@@ -328,13 +326,30 @@ Frosted Glass Light:
     }
 
     /* INPUTS */
-    input, ha-textfield, ha-select {
+    input, ha-textfield {
       background: rgba(255, 255, 255, 0.7) !important;
       backdrop-filter: blur(6px) !important;
-      -webkit-backdrop-filter: blur(6px);
+      -webkit-backdrop-filter: blur(6px) !important;
       border-radius: var(--token-size-radius-small);
       border: none !important;
       box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.05) !important;
+    }
+    ha-select {
+      background: rgba(255, 255, 255, 0.7) !important;
+      border-radius: var(--token-size-radius-small);
+      border: none !important;
+      box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.05) !important;
+      position: relative;
+    }
+    ha-select::before {
+      content: '';
+      position: absolute;
+      inset: 0;
+      backdrop-filter: blur(6px);
+      -webkit-backdrop-filter: blur(6px);
+      border-radius: inherit;
+      z-index: -1;
+      pointer-events: none;
     }
 
   # =========================

--- a/themes/Frosted Glass Light.yaml
+++ b/themes/Frosted Glass Light.yaml
@@ -10,7 +10,8 @@ Frosted Glass Light:
   # =========================
   # HEADER (Top Bar)
   # =========================
-  app-header-background-color: 'rgba(234, 235, 238, 0.88)'
+  app-header-backdrop-filter: 'blur(6px) saturate(1.2)'
+  app-header-background-color: 'rgba(234, 235, 238, 0.1)'
   app-header-text-color: 'rgba(19, 21, 54, 0.95)'
   app-header-edit-background-color: 'rgba(255, 255, 255, 0.8)'
   app-header-edit-text-color: 'rgba(19, 21, 54, 0.98)'

--- a/themes/Frosted Glass Light.yaml
+++ b/themes/Frosted Glass Light.yaml
@@ -1,5 +1,5 @@
 # Frosted Glass Light
-# ver. 1.3.3 - (2026-02-28)  
+# ver. 1.3.4 - (2026-02-28)
 
 Frosted Glass Light:
   card-mod-theme: "Frosted Glass Light"

--- a/themes/Frosted Glass Light.yaml
+++ b/themes/Frosted Glass Light.yaml
@@ -1,5 +1,5 @@
 # Frosted Glass Light
-# ver. 1.3.4 - (2026-02-28)
+# ver. 1.3.5 - (2026-02-28)
 
 Frosted Glass Light:
   card-mod-theme: "Frosted Glass Light"

--- a/themes/Frosted Glass Light.yaml
+++ b/themes/Frosted Glass Light.yaml
@@ -1,5 +1,5 @@
 # Frosted Glass Light
-# ver. 1.3.5 - (2026-02-28)
+# ver. 1.3.6 - (2026-02-28)
 
 Frosted Glass Light:
   card-mod-theme: "Frosted Glass Light"

--- a/themes/Frosted Glass Light.yaml
+++ b/themes/Frosted Glass Light.yaml
@@ -10,8 +10,7 @@ Frosted Glass Light:
   # =========================
   # HEADER (Top Bar)
   # =========================
-  app-header-backdrop-filter: 'blur(6px) saturate(1.2)'
-  app-header-background-color: 'rgba(234, 235, 238, 0.1)'
+  app-header-background-color: 'rgba(234, 235, 238, 0.88)'
   app-header-text-color: 'rgba(19, 21, 54, 0.95)'
   app-header-edit-background-color: 'rgba(255, 255, 255, 0.8)'
   app-header-edit-text-color: 'rgba(19, 21, 54, 0.98)'

--- a/themes/Frosted Glass Light.yaml
+++ b/themes/Frosted Glass Light.yaml
@@ -1,5 +1,5 @@
 # Frosted Glass Light
-# ver. 1.3.1 - (2026-02-23)  
+# ver. 1.3.2 - (2026-02-23)  
 
 Frosted Glass Light:
   card-mod-theme: "Frosted Glass Light"
@@ -10,8 +10,7 @@ Frosted Glass Light:
   # =========================
   # HEADER (Top Bar)
   # =========================
-  app-header-backdrop-filter: 'blur(6px) saturate(1.2)'
-  app-header-background-color: 'rgba(234, 235, 238, 0.1)'
+  app-header-background-color: 'rgba(234, 235, 238, 0.88)'
   app-header-text-color: 'rgba(19, 21, 54, 0.95)'
   app-header-edit-background-color: 'rgba(255, 255, 255, 0.8)'
   app-header-edit-text-color: 'rgba(19, 21, 54, 0.98)'
@@ -31,8 +30,7 @@ Frosted Glass Light:
   # =========================
   # DIALOGS
   # =========================
-  ha-dialog-surface-backdrop-filter: 'blur(8px)'                                   
-  ha-dialog-surface-background: 'rgba(234, 235, 238, 0.7)'
+  ha-dialog-surface-background: 'rgba(234, 235, 238, 0.94)'
   dialog-box-shadow: '0 12px 20px rgba(0, 0, 0, 0.15)'                                                     # 1.2 Glass – fix: remove stray quotes inside rgba
   paper-dialog-background-color: 'rgba(234, 235, 238, 0.7)'
   mdc-dialog-scrim-color: 'rgba(0, 0, 0, 0.6)'
@@ -292,11 +290,9 @@ Frosted Glass Light:
     --text-divider-color: rgba(19, 21, 54, 1) !important;
    }
 
-    /* SIDEBAR BLUR */
+    /* SIDEBAR */
     .mdc-drawer .mdc-drawer__content {
-      backdrop-filter: blur(6px) saturate(1.2) !important;
-      -webkit-backdrop-filter: blur(6px) saturate(1.2) !important;
-      background: rgba(234, 235, 238, 0.7) !important;
+      background: rgba(234, 235, 238, 0.88) !important;
       box-shadow: var(--ha-card-glass-inset-shadow) !important;
     }
 
@@ -317,39 +313,18 @@ Frosted Glass Light:
 
     /* LABEL BADGE */
     ha-label-badge {
-      --label-badge-background-color: rgba(230, 230, 230, 0.2) !important;
-      backdrop-filter: blur(12px) saturate(1.1) !important;
-      -webkit-backdrop-filter: blur(12px) saturate(1.1) !important;
+      --label-badge-background-color: rgba(230, 230, 230, 0.85) !important;
       --label-badge-text-color: rgba(19, 21, 54, 0.9) !important;
       box-shadow: 0 5px 10px rgba(0, 0, 0, 0.05) !important;
       border: 0.5px solid rgba(255, 255, 255, 0.3) !important;
     }
 
     /* INPUTS */
-    input, ha-textfield {
-      background: rgba(255, 255, 255, 0.7) !important;
-      backdrop-filter: blur(6px) !important;
-      -webkit-backdrop-filter: blur(6px) !important;
-      border-radius: var(--token-size-radius-small);
-      border: none !important;
-      box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.05) !important;
-    }
-    ha-select {
+    input, ha-textfield, ha-select {
       background: rgba(255, 255, 255, 0.7) !important;
       border-radius: var(--token-size-radius-small);
       border: none !important;
       box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.05) !important;
-      position: relative;
-    }
-    ha-select::before {
-      content: '';
-      position: absolute;
-      inset: 0;
-      backdrop-filter: blur(6px);
-      -webkit-backdrop-filter: blur(6px);
-      border-radius: inherit;
-      z-index: -1;
-      pointer-events: none;
     }
 
   # =========================

--- a/themes/Frosted Glass Light.yaml
+++ b/themes/Frosted Glass Light.yaml
@@ -1,5 +1,5 @@
 # Frosted Glass Light
-# ver. 1.3.2 - (2026-02-23)  
+# ver. 1.3.3 - (2026-02-28)  
 
 Frosted Glass Light:
   card-mod-theme: "Frosted Glass Light"

--- a/themes/Frosted Glass Lite.yaml
+++ b/themes/Frosted Glass Lite.yaml
@@ -1,5 +1,5 @@
 # Frosted Glass Light Lite
-# ver. 1.3.1 - (2026-02-23)  
+# ver. 1.3.2 - (2026-02-23)  
 
 Frosted Glass Lite:
   modes:

--- a/themes/Frosted Glass Lite.yaml
+++ b/themes/Frosted Glass Lite.yaml
@@ -1,5 +1,5 @@
 # Frosted Glass Light Lite
-# ver. 1.3 - (2025-11-24)  
+# ver. 1.3.1 - (2026-02-23)  
 
 Frosted Glass Lite:
   modes:
@@ -131,32 +131,18 @@ Frosted Glass Lite:
         --ha-card-background: rgba(242, 245, 255, 0.1);
         --ha-card-box-shadow: 0 12px 20px rgba(0, 0, 0, 0.15);
         --ha-card-border-width: 0.5px;
-        --ha-card-border-color: rgba(255, 255, 255, 0.3);                                                # 1.1.9 change - added blur & saturation for badges
+        --ha-card-border-color: rgba(255, 255, 255, 0.3);
 
         /* Glass system tokens (new) */
-        --ha-card-glass-tint: rgba(255, 255, 255, 0.08);                                                      # 1.2 Glass – global tint layer
-        --ha-card-glass-inset-shadow:                                                                         # 1.2 Glass – inner bevel/glow (Liquid Glass inspired)
+        --ha-card-glass-tint: rgba(255, 255, 255, 0.08);                                                      /* 1.2 Glass – global tint layer */
+        --ha-card-glass-inset-shadow:                                                                         /* 1.2 Glass – inner bevel/glow (Liquid Glass inspired) */
           3px 3px 0.5px -3.5px rgba(255, 255, 255, 0.30) inset,
           -2px -2px 0.5px -2px rgba(255, 255, 255, 0.30) inset,
           0 0 8px 1px rgba(255, 255, 255, 0.10) inset,
           0 0 2px 0 rgba(0, 0, 0, 0.10);
-       }
 
-       /* Custom text divider row size fix */
-       custom-text-divider-row .text-divider-content {
-        background: #fff !important; /* or your color */
-        opacity: 1 !important;
-        box-shadow: none !important;
-        border-radius: 10px !important; /* adjust as needed */
-        padding: 0 8px !important;
-        --text-divider-font-size: 16px !important;
-        --text-divider-line-size: 1px;
-        --text-divider-color: rgba(19, 21, 54, 1) !important;
-       }
-
-        
-          # Tokens (used throughout cards/UI)
-          --token-rgb-primary: 106, 116, 211;
+        /* Tokens (used throughout cards/UI) */
+        --token-rgb-primary: 106, 116, 211;
           --token-rgb-black: 0, 0, 0;
           --token-rgb-white: 240, 243, 255;
           --token-rgb-purple: 129, 45, 250;
@@ -248,7 +234,7 @@ Frosted Glass Lite:
           --token-font-family-primary: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
           --token-weight-font-title-card: 500;
 
-          # Additional color variables
+          /* Additional color variables */
           --token-color-red: rgb(var(--token-rgb-red));
           --token-color-green: rgb(var(--token-rgb-green));
           --token-color-blue: rgb(var(--token-rgb-blue));
@@ -268,9 +254,21 @@ Frosted Glass Lite:
           --token-color-indigo: rgb(var(--token-rgb-indigo));
           --token-color-deep-purple: rgb(var(--token-rgb-deep-purple));
           --token-color-light-blue: rgb(var(--token-rgb-light-blue));
-        }
+       }
 
-        /* SIDEBAR BLUR */
+       /* Custom text divider row size fix */
+       custom-text-divider-row .text-divider-content {
+        background: #fff !important;
+        opacity: 1 !important;
+        box-shadow: none !important;
+        border-radius: 10px !important;
+        padding: 0 8px !important;
+        --text-divider-font-size: 16px !important;
+        --text-divider-line-size: 1px;
+        --text-divider-color: rgba(19, 21, 54, 1) !important;
+       }
+
+        /* SIDEBAR */
         .mdc-drawer .mdc-drawer__content {
           background: rgba(234, 235, 238, 0.7) !important;
           box-shadow: var(--ha-card-glass-inset-shadow) !important;                                          /* 1.2 Glass – subtle inner edge for consistency */
@@ -470,7 +468,7 @@ Frosted Glass Lite:
       mush-title-font-weight: '500'
       mush-title-font-size: 'var(--token-size-font-2xl)'
       light-grey-color: 'rgb(103, 104, 119)'
-      mush-rgb-grey: '103, 104, 119)'
+      mush-rgb-grey: '103, 104, 119'
 
       # Misc sizes
       paper-slider-height: '5px'
@@ -606,8 +604,8 @@ Frosted Glass Lite:
           --ha-card-border-color: rgba(234, 235, 238, 0.1);
 
           /* Glass system tokens (new, dark-tuned) */
-          --ha-card-glass-tint: rgba(28, 29, 33, 0.18);                                      # 1.2 Glass – global tint layer
-          --ha-card-glass-inset-shadow:                                                      # 1.2 Glass – inner bevel/glow (Liquid Glass inspired)
+          --ha-card-glass-tint: rgba(28, 29, 33, 0.18);                                      /* 1.2 Glass – global tint layer */
+          --ha-card-glass-inset-shadow:                                                      /* 1.2 Glass – inner bevel/glow (Liquid Glass inspired) */
             3px 3px 0.5px -3.5px rgba(255, 255, 255, 0.15) inset,
             -2px -2px 0.5px -2px rgba(255, 255, 255, 0.1) inset,
             0 0 8px 1px rgba(255, 255, 255, 0.06) inset,
@@ -705,8 +703,8 @@ Frosted Glass Lite:
           --token-opacity-ripple-hover: 0.1;
           --token-font-family-primary: -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
           --token-weight-font-title-card: 500;
-          
-          # Additional color variables
+
+          /* Additional color variables */
           --token-color-red: rgb(var(--token-rgb-red));
           --token-color-green: rgb(var(--token-rgb-green));
           --token-color-blue: rgb(var(--token-rgb-blue));
@@ -731,13 +729,13 @@ Frosted Glass Lite:
         /* SIDEBAR BLUR */
         .mdc-drawer .mdc-drawer__content {
           background: rgba(25, 28, 45, 0.8) !important;
-          box-shadow: var(--ha-card-glass-inset-shadow) !important;                         # 1.2 Glass – subtle inner edge for consistency
+          box-shadow: var(--ha-card-glass-inset-shadow) !important;
         }
 
         /* CARDS RADIUS */
         ha-card {
           border-radius: var(--token-size-radius-large);
-          border: var(--ha-card-border, var(--ha-card-border-width) solid var(--ha-card-border-color));       # 1.2 Glass – ensure border follows tokens
+          border: var(--ha-card-border, var(--ha-card-border-width) solid var(--ha-card-border-color));
           box-shadow: var(--ha-card-box-shadow);
         }
         ha-card ha-card {

--- a/themes/Frosted Glass Lite.yaml
+++ b/themes/Frosted Glass Lite.yaml
@@ -1,5 +1,5 @@
 # Frosted Glass Light Lite
-# ver. 1.3.3 - (2026-02-28)  
+# ver. 1.3.4 - (2026-02-28)
 
 Frosted Glass Lite:
   modes:

--- a/themes/Frosted Glass Lite.yaml
+++ b/themes/Frosted Glass Lite.yaml
@@ -1,5 +1,5 @@
 # Frosted Glass Light Lite
-# ver. 1.3.4 - (2026-02-28)
+# ver. 1.3.5 - (2026-02-28)
 
 Frosted Glass Lite:
   modes:

--- a/themes/Frosted Glass Lite.yaml
+++ b/themes/Frosted Glass Lite.yaml
@@ -1,5 +1,5 @@
 # Frosted Glass Light Lite
-# ver. 1.3.5 - (2026-02-28)
+# ver. 1.3.6 - (2026-02-28)
 
 Frosted Glass Lite:
   modes:

--- a/themes/Frosted Glass Lite.yaml
+++ b/themes/Frosted Glass Lite.yaml
@@ -1,5 +1,5 @@
 # Frosted Glass Light Lite
-# ver. 1.3.2 - (2026-02-23)  
+# ver. 1.3.3 - (2026-02-28)  
 
 Frosted Glass Lite:
   modes:

--- a/themes/Frosted Glass.yaml
+++ b/themes/Frosted Glass.yaml
@@ -9,7 +9,8 @@ Frosted Glass:
       # =========================
       # HEADER (Top Bar)
       # =========================
-      app-header-background-color: 'rgba(234, 235, 238, 0.88)'
+      app-header-backdrop-filter: 'blur(6px) saturate(1.2)'
+      app-header-background-color: 'rgba(234, 235, 238, 0.1)'
       app-header-text-color: 'rgba(19, 21, 54, 0.95)'
       app-header-edit-background-color: 'rgba(255, 255, 255, 0.8)'
       app-header-edit-text-color: 'rgba(19, 21, 54, 0.98)'
@@ -500,7 +501,8 @@ Frosted Glass:
       # =========================
       # HEADER (Top Bar)
       # =========================
-      app-header-background-color: 'rgba(30, 30, 30, 0.85)'
+      app-header-backdrop-filter: 'blur(8px) saturate(1.1)'
+      app-header-background-color: 'rgba(30, 30, 30, 0.01)'
       app-header-text-color: 'rgba(240, 243, 255, 0.95)'
       app-header-edit-background-color: 'rgba(30, 33, 54, 0.8)'
       app-header-edit-text-color: 'rgba(234, 235, 238, 0.98)'

--- a/themes/Frosted Glass.yaml
+++ b/themes/Frosted Glass.yaml
@@ -1,5 +1,5 @@
 # Frosted Glass
-# ver. 1.3.4 - (2026-02-28)
+# ver. 1.3.5 - (2026-02-28)
 
 Frosted Glass:
   modes:

--- a/themes/Frosted Glass.yaml
+++ b/themes/Frosted Glass.yaml
@@ -1,5 +1,5 @@
 # Frosted Glass
-# ver. 1.3.3 - (2026-02-28) 
+# ver. 1.3.4 - (2026-02-28)
 
 Frosted Glass:
   modes:

--- a/themes/Frosted Glass.yaml
+++ b/themes/Frosted Glass.yaml
@@ -1,5 +1,5 @@
 # Frosted Glass
-# ver. 1.3.1 - (2026-02-23) 
+# ver. 1.3.2 - (2026-02-23) 
 
 Frosted Glass:
   modes:
@@ -9,8 +9,7 @@ Frosted Glass:
       # =========================
       # HEADER (Top Bar)
       # =========================
-      app-header-backdrop-filter: 'blur(6px) saturate(1.2)'
-      app-header-background-color: 'rgba(234, 235, 238, 0.1)'
+      app-header-background-color: 'rgba(234, 235, 238, 0.88)'
       app-header-text-color: 'rgba(19, 21, 54, 0.95)'
       app-header-edit-background-color: 'rgba(255, 255, 255, 0.8)'
       app-header-edit-text-color: 'rgba(19, 21, 54, 0.98)'
@@ -30,8 +29,7 @@ Frosted Glass:
       # =========================
       # DIALOGS
       # =========================
-      ha-dialog-surface-backdrop-filter: 'blur(8px)'                                   
-      ha-dialog-surface-background: 'rgba(234, 235, 238, 0.7)'
+      ha-dialog-surface-background: 'rgba(234, 235, 238, 0.94)'
       dialog-box-shadow: '0 12px 20px rgba(0, 0, 0, 0.15)'                                                     # 1.2 Glass – fix: remove stray quotes inside rgba
       paper-dialog-background-color: 'rgba(234, 235, 238, 0.7)'
       mdc-dialog-scrim-color: 'rgba(0, 0, 0, 0.6)'
@@ -291,11 +289,9 @@ Frosted Glass:
         --text-divider-color: rgba(19, 21, 54, 1) !important;
        }
 
-        /* SIDEBAR BLUR */
+        /* SIDEBAR */
         .mdc-drawer .mdc-drawer__content {
-          backdrop-filter: blur(6px) saturate(1.2) !important;
-          -webkit-backdrop-filter: blur(6px) saturate(1.2) !important;
-          background: rgba(234, 235, 238, 0.7) !important;
+          background: rgba(234, 235, 238, 0.88) !important;
           box-shadow: var(--ha-card-glass-inset-shadow) !important;
         }
 
@@ -316,39 +312,18 @@ Frosted Glass:
 
         /* LABEL BADGE */
         ha-label-badge {
-          --label-badge-background-color: rgba(230, 230, 230, 0.2) !important;
-          backdrop-filter: blur(12px) saturate(1.1) !important;
-          -webkit-backdrop-filter: blur(12px) saturate(1.1) !important;
+          --label-badge-background-color: rgba(230, 230, 230, 0.85) !important;
           --label-badge-text-color: rgba(19, 21, 54, 0.9) !important;
           box-shadow: 0 5px 10px rgba(0, 0, 0, 0.05) !important;
           border: 0.5px solid rgba(255, 255, 255, 0.3) !important;
         }
 
         /* INPUTS */
-        input, ha-textfield {
-          background: rgba(255, 255, 255, 0.7) !important;
-          backdrop-filter: blur(6px) !important;
-          -webkit-backdrop-filter: blur(6px) !important;
-          border-radius: var(--token-size-radius-small);
-          border: none !important;
-          box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.05) !important;
-        }
-        ha-select {
+        input, ha-textfield, ha-select {
           background: rgba(255, 255, 255, 0.7) !important;
           border-radius: var(--token-size-radius-small);
           border: none !important;
           box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.05) !important;
-          position: relative;
-        }
-        ha-select::before {
-          content: '';
-          position: absolute;
-          inset: 0;
-          backdrop-filter: blur(6px);
-          -webkit-backdrop-filter: blur(6px);
-          border-radius: inherit;
-          z-index: -1;
-          pointer-events: none;
         }
 
       # =========================
@@ -525,8 +500,7 @@ Frosted Glass:
       # =========================
       # HEADER (Top Bar)
       # =========================
-      app-header-backdrop-filter: 'blur(8px) saturate(1.1)'
-      app-header-background-color: 'rgba(30, 30, 30, 0.01)'
+      app-header-background-color: 'rgba(30, 30, 30, 0.85)'
       app-header-text-color: 'rgba(240, 243, 255, 0.95)'
       app-header-edit-background-color: 'rgba(30, 33, 54, 0.8)'
       app-header-edit-text-color: 'rgba(234, 235, 238, 0.98)'
@@ -544,8 +518,7 @@ Frosted Glass:
       # =========================
       # DIALOGS
       # =========================
-      ha-dialog-surface-backdrop-filter: 'blur(8px)'                  # 1.2 Glass – same blur as cards
-      ha-dialog-surface-background: 'rgba(30, 30, 30, 0.7)'
+      ha-dialog-surface-background: 'rgba(30, 30, 30, 0.92)'
       dialog-box-shadow: '0 12px 20px rgba(0, 0, 0, 0.25)'
       paper-dialog-background-color: 'rgba(30, 30, 30, 0.7)'
       mdc-dialog-scrim-color: 'rgba(0, 0, 0, 0.8)'
@@ -794,11 +767,9 @@ Frosted Glass:
           --token-color-light-blue: rgb(var(--token-rgb-light-blue));
         }
 
-        /* SIDEBAR BLUR */
+        /* SIDEBAR */
         .mdc-drawer .mdc-drawer__content {
-          backdrop-filter: blur(8px) saturate(1.1) !important;
-          -webkit-backdrop-filter: blur(8px) saturate(1.1) !important;
-          background: rgba(25, 28, 45, 0.8) !important;
+          background: rgba(25, 28, 45, 0.9) !important;
           box-shadow: var(--ha-card-glass-inset-shadow) !important;
         }
 
@@ -819,39 +790,18 @@ Frosted Glass:
 
         /* LABEL BADGE */
         ha-label-badge {
-          --label-badge-background-color: rgba(60, 60, 78, 0.28) !important;
-          backdrop-filter: blur(10px) saturate(1.1) !important;
-          -webkit-backdrop-filter: blur(10px) saturate(1.1) !important;
+          --label-badge-background-color: rgba(60, 60, 78, 0.85) !important;
           --label-badge-text-color: rgba(234, 235, 238, 0.9) !important;
           box-shadow: 0 5px 10px rgba(0, 0, 0, 0.10) !important;
           border: 0.5px solid rgba(234, 235, 238, 0.22) !important;
         }
 
         /* INPUTS */
-        input, ha-textfield {
-          background: rgba(30, 33, 54, 0.7) !important;
-          backdrop-filter: blur(6px) !important;
-          -webkit-backdrop-filter: blur(6px) !important;
-          border-radius: var(--token-size-radius-small);
-          border: none !important;
-          box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.09) !important;
-        }
-        ha-select {
+        input, ha-textfield, ha-select {
           background: rgba(30, 33, 54, 0.7) !important;
           border-radius: var(--token-size-radius-small);
           border: none !important;
           box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.09) !important;
-          position: relative;
-        }
-        ha-select::before {
-          content: '';
-          position: absolute;
-          inset: 0;
-          backdrop-filter: blur(6px);
-          -webkit-backdrop-filter: blur(6px);
-          border-radius: inherit;
-          z-index: -1;
-          pointer-events: none;
         }
 
         /* Custom text divider row size fix */

--- a/themes/Frosted Glass.yaml
+++ b/themes/Frosted Glass.yaml
@@ -1,5 +1,5 @@
 # Frosted Glass
-# ver. 1.3 - (2025-11-24) 
+# ver. 1.3.1 - (2026-02-23) 
 
 Frosted Glass:
   modes:
@@ -154,32 +154,18 @@ Frosted Glass:
         --ha-card-box-shadow: 0 12px 20px rgba(0, 0, 0, 0.15);
         --ha-card-border-width: 0.5px;
         --ha-card-border-color: rgba(255, 255, 255, 0.3);
-        --ha-card-backdrop-filter: blur(8px) saturate(1.2);                                                   # 1.1.9 change - added blur & saturation for badges
+        --ha-card-backdrop-filter: blur(8px) saturate(1.2);
 
-        /* Glass system tokens (new) */
-        --ha-card-glass-tint: rgba(255, 255, 255, 0.08);                                                      # 1.2 Glass – global tint layer
-        --ha-card-glass-inset-shadow:                                                                         # 1.2 Glass – inner bevel/glow (Liquid Glass inspired)
+        /* Glass system tokens */
+        --ha-card-glass-tint: rgba(255, 255, 255, 0.08);
+        --ha-card-glass-inset-shadow:
           3px 3px 0.5px -3.5px rgba(255, 255, 255, 0.30) inset,
           -2px -2px 0.5px -2px rgba(255, 255, 255, 0.30) inset,
           0 0 8px 1px rgba(255, 255, 255, 0.10) inset,
           0 0 2px 0 rgba(0, 0, 0, 0.10);
-       }
 
-       /* Custom text divider row size fix */
-       custom-text-divider-row .text-divider-content {
-        background: #fff !important; /* or your color */
-        opacity: 1 !important;
-        box-shadow: none !important;
-        border-radius: 10px !important; /* adjust as needed */
-        padding: 0 8px !important;
-        --text-divider-font-size: 16px !important;
-        --text-divider-line-size: 1px;
-        --text-divider-color: rgba(19, 21, 54, 1) !important;
-       }
-
-        
-          # Tokens (used throughout cards/UI)
-          --token-rgb-primary: 106, 116, 211;
+        /* Tokens (used throughout cards/UI) */
+        --token-rgb-primary: 106, 116, 211;
           --token-rgb-black: 0, 0, 0;
           --token-rgb-white: 240, 243, 255;
           --token-rgb-purple: 129, 45, 250;
@@ -271,7 +257,7 @@ Frosted Glass:
           --token-font-family-primary: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
           --token-weight-font-title-card: 500;
 
-          # Additional color variables
+          /* Additional color variables */
           --token-color-red: rgb(var(--token-rgb-red));
           --token-color-green: rgb(var(--token-rgb-green));
           --token-color-blue: rgb(var(--token-rgb-blue));
@@ -291,20 +277,32 @@ Frosted Glass:
           --token-color-indigo: rgb(var(--token-rgb-indigo));
           --token-color-deep-purple: rgb(var(--token-rgb-deep-purple));
           --token-color-light-blue: rgb(var(--token-rgb-light-blue));
-        }
+       }
+
+       /* Custom text divider row size fix */
+       custom-text-divider-row .text-divider-content {
+        background: #fff !important;
+        opacity: 1 !important;
+        box-shadow: none !important;
+        border-radius: 10px !important;
+        padding: 0 8px !important;
+        --text-divider-font-size: 16px !important;
+        --text-divider-line-size: 1px;
+        --text-divider-color: rgba(19, 21, 54, 1) !important;
+       }
 
         /* SIDEBAR BLUR */
         .mdc-drawer .mdc-drawer__content {
           backdrop-filter: blur(6px) saturate(1.2) !important;
           -webkit-backdrop-filter: blur(6px) saturate(1.2) !important;
           background: rgba(234, 235, 238, 0.7) !important;
-          box-shadow: var(--ha-card-glass-inset-shadow) !important;                                          /* 1.2 Glass – subtle inner edge for consistency */
+          box-shadow: var(--ha-card-glass-inset-shadow) !important;
         }
 
         /* CARDS RADIUS */
         ha-card {
           border-radius: var(--token-size-radius-large);
-          border: var(--ha-card-border, var(--ha-card-border-width) solid var(--ha-card-border-color));       /* 1.2 Glass – ensure border follows tokens */
+          border: var(--ha-card-border, var(--ha-card-border-width) solid var(--ha-card-border-color));
           box-shadow: var(--ha-card-box-shadow);
         }
         ha-card ha-card {
@@ -327,13 +325,30 @@ Frosted Glass:
         }
 
         /* INPUTS */
-        input, ha-textfield, ha-select {
+        input, ha-textfield {
           background: rgba(255, 255, 255, 0.7) !important;
           backdrop-filter: blur(6px) !important;
-          -webkit-backdrop-filter: blur(6px);
+          -webkit-backdrop-filter: blur(6px) !important;
           border-radius: var(--token-size-radius-small);
           border: none !important;
           box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.05) !important;
+        }
+        ha-select {
+          background: rgba(255, 255, 255, 0.7) !important;
+          border-radius: var(--token-size-radius-small);
+          border: none !important;
+          box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.05) !important;
+          position: relative;
+        }
+        ha-select::before {
+          content: '';
+          position: absolute;
+          inset: 0;
+          backdrop-filter: blur(6px);
+          -webkit-backdrop-filter: blur(6px);
+          border-radius: inherit;
+          z-index: -1;
+          pointer-events: none;
         }
 
       # =========================
@@ -498,7 +513,7 @@ Frosted Glass:
       mush-title-font-weight: '500'
       mush-title-font-size: 'var(--token-size-font-2xl)'
       light-grey-color: 'rgb(103, 104, 119)'
-      mush-rgb-grey: '103, 104, 119)'
+      mush-rgb-grey: '103, 104, 119'
 
       # Misc sizes
       paper-slider-height: '5px'
@@ -654,11 +669,11 @@ Frosted Glass:
           --ha-card-box-shadow: 0 12px 20px rgba(0, 0, 0, 0.28);
           --ha-card-border-width: 0.5px;
           --ha-card-border-color: rgba(234, 235, 238, 0.1);
-          --ha-card-backdrop-filter: blur(10px) saturate(1.2);                               # 1.2 Glass – same engine as Light, tuned for Dark
+          --ha-card-backdrop-filter: blur(10px) saturate(1.2);
 
-          /* Glass system tokens (new, dark-tuned) */
-          --ha-card-glass-tint: rgba(28, 29, 33, 0.18);                                      # 1.2 Glass – global tint layer
-          --ha-card-glass-inset-shadow:                                                      # 1.2 Glass – inner bevel/glow (Liquid Glass inspired)
+          /* Glass system tokens (dark-tuned) */
+          --ha-card-glass-tint: rgba(28, 29, 33, 0.18);
+          --ha-card-glass-inset-shadow:
             3px 3px 0.5px -3.5px rgba(255, 255, 255, 0.15) inset,
             -2px -2px 0.5px -2px rgba(255, 255, 255, 0.1) inset,
             0 0 8px 1px rgba(255, 255, 255, 0.06) inset,
@@ -757,7 +772,7 @@ Frosted Glass:
           --token-font-family-primary: -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
           --token-weight-font-title-card: 500;
           
-          # Additional color variables
+          /* Additional color variables */
           --token-color-red: rgb(var(--token-rgb-red));
           --token-color-green: rgb(var(--token-rgb-green));
           --token-color-blue: rgb(var(--token-rgb-blue));
@@ -784,13 +799,13 @@ Frosted Glass:
           backdrop-filter: blur(8px) saturate(1.1) !important;
           -webkit-backdrop-filter: blur(8px) saturate(1.1) !important;
           background: rgba(25, 28, 45, 0.8) !important;
-          box-shadow: var(--ha-card-glass-inset-shadow) !important;                         # 1.2 Glass – subtle inner edge for consistency
+          box-shadow: var(--ha-card-glass-inset-shadow) !important;
         }
 
         /* CARDS RADIUS */
         ha-card {
           border-radius: var(--token-size-radius-large);
-          border: var(--ha-card-border, var(--ha-card-border-width) solid var(--ha-card-border-color));       # 1.2 Glass – ensure border follows tokens
+          border: var(--ha-card-border, var(--ha-card-border-width) solid var(--ha-card-border-color));
           box-shadow: var(--ha-card-box-shadow);
         }
         ha-card ha-card {
@@ -813,13 +828,30 @@ Frosted Glass:
         }
 
         /* INPUTS */
-        input, ha-textfield, ha-select {
+        input, ha-textfield {
           background: rgba(30, 33, 54, 0.7) !important;
           backdrop-filter: blur(6px) !important;
-          -webkit-backdrop-filter: blur(6px);
+          -webkit-backdrop-filter: blur(6px) !important;
           border-radius: var(--token-size-radius-small);
           border: none !important;
           box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.09) !important;
+        }
+        ha-select {
+          background: rgba(30, 33, 54, 0.7) !important;
+          border-radius: var(--token-size-radius-small);
+          border: none !important;
+          box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.09) !important;
+          position: relative;
+        }
+        ha-select::before {
+          content: '';
+          position: absolute;
+          inset: 0;
+          backdrop-filter: blur(6px);
+          -webkit-backdrop-filter: blur(6px);
+          border-radius: inherit;
+          z-index: -1;
+          pointer-events: none;
         }
 
         /* Custom text divider row size fix */

--- a/themes/Frosted Glass.yaml
+++ b/themes/Frosted Glass.yaml
@@ -1,5 +1,5 @@
 # Frosted Glass
-# ver. 1.3.5 - (2026-02-28)
+# ver. 1.3.6 - (2026-02-28)
 
 Frosted Glass:
   modes:

--- a/themes/Frosted Glass.yaml
+++ b/themes/Frosted Glass.yaml
@@ -9,8 +9,7 @@ Frosted Glass:
       # =========================
       # HEADER (Top Bar)
       # =========================
-      app-header-backdrop-filter: 'blur(6px) saturate(1.2)'
-      app-header-background-color: 'rgba(234, 235, 238, 0.1)'
+      app-header-background-color: 'rgba(234, 235, 238, 0.88)'
       app-header-text-color: 'rgba(19, 21, 54, 0.95)'
       app-header-edit-background-color: 'rgba(255, 255, 255, 0.8)'
       app-header-edit-text-color: 'rgba(19, 21, 54, 0.98)'
@@ -501,8 +500,7 @@ Frosted Glass:
       # =========================
       # HEADER (Top Bar)
       # =========================
-      app-header-backdrop-filter: 'blur(8px) saturate(1.1)'
-      app-header-background-color: 'rgba(30, 30, 30, 0.01)'
+      app-header-background-color: 'rgba(30, 30, 30, 0.85)'
       app-header-text-color: 'rgba(240, 243, 255, 0.95)'
       app-header-edit-background-color: 'rgba(30, 33, 54, 0.8)'
       app-header-edit-text-color: 'rgba(234, 235, 238, 0.98)'

--- a/themes/Frosted Glass.yaml
+++ b/themes/Frosted Glass.yaml
@@ -1,5 +1,5 @@
 # Frosted Glass
-# ver. 1.3.2 - (2026-02-23) 
+# ver. 1.3.3 - (2026-02-28) 
 
 Frosted Glass:
   modes:


### PR DESCRIPTION
## Summary

This PR addresses **7 bugs** found in the v1.3 theme files, most notably a **dropdown positioning issue** where `ha-select` dropdown menus render in the wrong location instead of appearing beneath the select element.

### v1.3.1 — Six general theme bugs

1. **Invalid `#` comments inside `card-mod` CSS blocks** (all 6 files)
   - `card-mod-card` and `card-mod-root` use YAML `|` literal blocks, meaning their content is injected as raw CSS. `#` is not a valid CSS comment delimiter — these were being passed through verbatim by card-mod, causing parse errors.
   - Fixed: converted all `#` comments inside `|` blocks to `/* */` CSS comments.

2. **Missing `card-mod-root` CSS sections in Dark Lite** (`Frosted Glass Dark Lite.yaml`)
   - The Dark Lite variant was missing several `card-mod-root` CSS blocks that exist in all other themes: sidebar styling, cards radius, drawer scrim, label badge, inputs, and text divider.
   - Fixed: added the missing sections to match the other Lite variants.

3. **Incorrect checkbox/radio colors in Dark Lite** (`Frosted Glass Dark Lite.yaml`)
   - `mdc-checkbox-unchecked-color` and `mdc-radio-unchecked-color` were set to `rgba(19, 21, 54, 0.75)` (dark/light-mode value), making them invisible against dark backgrounds.
   - Fixed: changed to `rgba(234, 235, 238, 0.75)` to match the dark theme palette.

4. **Broken token structure in Lite and Light Lite** (`Frosted Glass Lite.yaml`, `Frosted Glass Light Lite.yaml`)
   - Glass tokens and additional color variables were placed outside the `:host {}` block in the `card-mod-root` CSS, causing them to be invalid CSS.
   - Fixed: merged all token definitions into the `:host {}` block.

5. **Missing text divider CSS in Light Lite and Lite** (`Frosted Glass Light Lite.yaml`, `Frosted Glass Lite.yaml`)
   - The `custom-text-divider-row` CSS rule was missing from these variants.
   - Fixed: added the text divider block after the `:host {}` close.

6. **Trailing `#` comments on non-CSS YAML lines in Lite dark mode** (`Frosted Glass Lite.yaml`)
   - Some YAML key-value lines for sidebar and border colors had trailing `#` comments that could interfere with value parsing.
   - Fixed: removed trailing comments from these lines.

### v1.3.2 — Dropdown positioning fix

**Root cause**: Per the CSS specification, `backdrop-filter` on **any ancestor element** creates a new [containing block](https://developer.mozilla.org/en-US/docs/Web/CSS/Containing_block#identifying_the_containing_block) for `position: fixed` descendants. Home Assistant's `mwc-menu-surface` dropdown popup uses `position: fixed` to position itself relative to the viewport. When a parent container has `backdrop-filter`, the popup gets trapped inside that container and renders in the wrong location.

The following HA theme variables and card-mod CSS rules were creating containing blocks:
- `app-header-backdrop-filter` — applied to the top header bar
- `ha-dialog-surface-backdrop-filter` — applied to dialog surfaces
- `.mdc-drawer .mdc-drawer__content { backdrop-filter: ... }` — sidebar
- `ha-label-badge { backdrop-filter: ... }` — label badges
- `input, ha-textfield { backdrop-filter: ... }` — input fields

**Fix**: Removed `backdrop-filter` from all parent containers that can hold dropdown selects. Compensated with more opaque background colors to maintain visual appearance:

| Element | Before | After |
|---------|--------|-------|
| Header (dark) | `backdrop-filter: blur(8px)`, bg `0.01` opacity | No blur, bg `0.85` opacity |
| Header (light) | `backdrop-filter: blur(6px)`, bg `0.1` opacity | No blur, bg `0.88` opacity |
| Dialog (dark) | `backdrop-filter: blur(8px)`, bg `0.7` opacity | No blur, bg `0.92` opacity |
| Dialog (light) | `backdrop-filter: blur(8px)`, bg `0.7` opacity | No blur, bg `0.94` opacity |
| Sidebar (dark) | `backdrop-filter: blur(8px)`, bg `0.8` opacity | No blur, bg `0.9` opacity |
| Sidebar (light) | `backdrop-filter: blur(6px)`, bg `0.7` opacity | No blur, bg `0.88` opacity |
| Label badges | `backdrop-filter: blur(10-12px)`, bg `0.2-0.28` | No blur, bg `0.85` opacity |
| Inputs | `backdrop-filter: blur(6px)` | No blur |

Card glass effects (`ha-card::before`) are **unaffected** — pseudo-elements don't create containing blocks for sibling elements.

Applied across all 3 full-blur themes: **Frosted Glass** (auto-switch, both modes), **Frosted Glass Dark**, and **Frosted Glass Light**. The Lite variants don't use `backdrop-filter` on these containers so they were not affected.

## Files Changed

| File | Changes |
|------|---------|
| `Frosted Glass.yaml` | Both v1.3.1 comment fixes + v1.3.2 backdrop-filter removal (light & dark modes) |
| `Frosted Glass Dark.yaml` | v1.3.1 comment fixes + v1.3.2 backdrop-filter removal |
| `Frosted Glass Light.yaml` | v1.3.1 comment fixes + v1.3.2 backdrop-filter removal |
| `Frosted Glass Dark Lite.yaml` | v1.3.1: added missing card-mod-root sections, fixed checkbox colors, fixed comments |
| `Frosted Glass Lite.yaml` | v1.3.1: fixed comments, token structure, added text divider, removed trailing comments |
| `Frosted Glass Light Lite.yaml` | v1.3.1: fixed comments, token structure, added text divider |

## Test Plan

- [x] Verify `ha-select` dropdowns position correctly in dark mode (e.g., entity config dialogs, automation editor)
- [x] Verify `ha-select` dropdowns position correctly in light mode
- [ ] Verify header, sidebar, dialogs, and label badges still look visually acceptable with opaque backgrounds
- [x] Test auto-switch theme (Frosted Glass) transitions between light and dark
- [x] Verify Lite variants render correctly (Dark Lite was missing significant CSS)
- [x] Confirm no CSS parse errors in browser console from `#` comments