### PR TITLE
Fix header blur, dropdowns, and 5 upstream issues

### DIFF
--- a/themes/Frosted Glass Dark Lite.yaml
+++ b/themes/Frosted Glass Dark Lite.yaml
@@ -1,5 +1,5 @@
 # Frosted Glass Dark Lite
-# ver. 1.3.1 - (2026-02-23) 
+# ver. 1.3.2 - (2026-02-23) 
 
 Frosted Glass Dark Lite:
   card-mod-theme: 'Frosted Glass Dark Lite'

--- a/themes/Frosted Glass Dark Lite.yaml
+++ b/themes/Frosted Glass Dark Lite.yaml
@@ -1,5 +1,5 @@
 # Frosted Glass Dark Lite
-# ver. 1.3.6 - (2026-02-28)
+# ver. 1.3.7 - (2026-02-28)
 
 Frosted Glass Dark Lite:
   card-mod-theme: 'Frosted Glass Dark Lite'

--- a/themes/Frosted Glass Dark Lite.yaml
+++ b/themes/Frosted Glass Dark Lite.yaml
@@ -1,5 +1,5 @@
 # Frosted Glass Dark Lite
-# ver. 1.3.2 - (2026-02-23) 
+# ver. 1.3.3 - (2026-02-28) 
 
 Frosted Glass Dark Lite:
   card-mod-theme: 'Frosted Glass Dark Lite'

--- a/themes/Frosted Glass Dark Lite.yaml
+++ b/themes/Frosted Glass Dark Lite.yaml
@@ -1,5 +1,5 @@
 # Frosted Glass Dark Lite
-# ver. 1.3.3 - (2026-02-28) 
+# ver. 1.3.4 - (2026-02-28)
 
 Frosted Glass Dark Lite:
   card-mod-theme: 'Frosted Glass Dark Lite'

--- a/themes/Frosted Glass Dark Lite.yaml
+++ b/themes/Frosted Glass Dark Lite.yaml
@@ -1,5 +1,5 @@
 # Frosted Glass Dark Lite
-# ver. 1.3 - (2025-11-24) 
+# ver. 1.3.1 - (2026-02-23) 
 
 Frosted Glass Dark Lite:
   card-mod-theme: 'Frosted Glass Dark Lite'
@@ -134,9 +134,9 @@ Frosted Glass Dark Lite:
       --ha-card-border-width: 0.5px;
       --ha-card-border-color: rgba(234, 235, 238, 0.1);
 
-      /* Glass system tokens (new, dark-tuned) */
-      --ha-card-glass-tint: rgba(28, 29, 33, 0.18);                                      # 1.2 Glass – global tint layer
-      --ha-card-glass-inset-shadow:                                                      # 1.2 Glass – inner bevel/glow (Liquid Glass inspired)
+      /* Glass system tokens (dark-tuned) */
+      --ha-card-glass-tint: rgba(28, 29, 33, 0.18);
+      --ha-card-glass-inset-shadow:
         3px 3px 0.5px -3.5px rgba(255, 255, 255, 0.15) inset,
         -2px -2px 0.5px -2px rgba(255, 255, 255, 0.1) inset,
         0 0 8px 1px rgba(255, 255, 255, 0.06) inset,
@@ -235,7 +235,7 @@ Frosted Glass Dark Lite:
       --token-font-family-primary: -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
       --token-weight-font-title-card: 500;
       
-      # Additional color variables
+      /* Additional color variables */
       --token-color-red: rgb(var(--token-rgb-red));
       --token-color-green: rgb(var(--token-rgb-green));
       --token-color-blue: rgb(var(--token-rgb-blue));
@@ -255,6 +255,55 @@ Frosted Glass Dark Lite:
       --token-color-indigo: rgb(var(--token-rgb-indigo));
       --token-color-deep-purple: rgb(var(--token-rgb-deep-purple));
       --token-color-light-blue: rgb(var(--token-rgb-light-blue));
+    }
+
+    /* SIDEBAR */
+    .mdc-drawer .mdc-drawer__content {
+      background: rgba(25, 28, 45, 0.8) !important;
+      box-shadow: var(--ha-card-glass-inset-shadow) !important;
+    }
+
+    /* CARDS RADIUS */
+    ha-card {
+      border-radius: var(--token-size-radius-large);
+      border: var(--ha-card-border, var(--ha-card-border-width) solid var(--ha-card-border-color));
+      box-shadow: var(--ha-card-box-shadow);
+    }
+    ha-card ha-card {
+      --ha-card-border-width: 0px;
+    }
+
+    /* DRAWER SCRIM */
+    ha-drawer {
+      --mdc-drawer-scrim-color: rgba(0, 0, 0, 0.8) !important;
+    }
+
+    /* LABEL BADGE */
+    ha-label-badge {
+      --label-badge-background-color: rgba(60, 60, 78, 0.28) !important;
+      --label-badge-text-color: rgba(234, 235, 238, 0.9) !important;
+      box-shadow: 0 5px 10px rgba(0, 0, 0, 0.10) !important;
+      border: 0.5px solid rgba(234, 235, 238, 0.22) !important;
+    }
+
+    /* INPUTS */
+    input, ha-textfield, ha-select {
+      background: rgba(30, 33, 54, 0.7) !important;
+      border-radius: var(--token-size-radius-small);
+      border: none !important;
+      box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.09) !important;
+    }
+
+    /* Custom text divider row size fix */
+    custom-text-divider-row .text-divider-content {
+      background: #181929 !important;
+      opacity: 1 !important;
+      box-shadow: none !important;
+      border-radius: 10px !important;
+      padding: 0 8px !important;
+      --text-divider-font-size: 16px !important;
+      --text-divider-line-size: 1px;
+      --text-divider-color: rgba(234, 235, 238, 1) !important;
     }
 
   # =========================
@@ -388,8 +437,8 @@ Frosted Glass Dark Lite:
   paper-toggle-button-checked-bar-color: 'rgb(106, 116, 211)'
   paper-toggle-button-unchecked-button-color: 'rgba(234, 235, 238, 0.3)'
   paper-toggle-button-unchecked-bar-color: 'rgba(234, 235, 238, 0.18)'
-  mdc-checkbox-unchecked-color: 'rgba(19, 21, 54, 0.75)'
-  mdc-radio-unchecked-color: 'rgba(19, 21, 54, 0.75)'
+  mdc-checkbox-unchecked-color: 'rgba(234, 235, 238, 0.75)'
+  mdc-radio-unchecked-color: 'rgba(234, 235, 238, 0.75)'
   mdc-ripple-hover-opacity: '0.1'
 
   # Inputs

--- a/themes/Frosted Glass Dark Lite.yaml
+++ b/themes/Frosted Glass Dark Lite.yaml
@@ -1,5 +1,5 @@
 # Frosted Glass Dark Lite
-# ver. 1.3.5 - (2026-02-28)
+# ver. 1.3.6 - (2026-02-28)
 
 Frosted Glass Dark Lite:
   card-mod-theme: 'Frosted Glass Dark Lite'

--- a/themes/Frosted Glass Dark Lite.yaml
+++ b/themes/Frosted Glass Dark Lite.yaml
@@ -1,5 +1,5 @@
 # Frosted Glass Dark Lite
-# ver. 1.3.4 - (2026-02-28)
+# ver. 1.3.5 - (2026-02-28)
 
 Frosted Glass Dark Lite:
   card-mod-theme: 'Frosted Glass Dark Lite'

--- a/themes/Frosted Glass Dark Lite.yaml
+++ b/themes/Frosted Glass Dark Lite.yaml
@@ -1,5 +1,5 @@
 # Frosted Glass Dark Lite
-# ver. 1.3.7 - (2026-02-28)
+# ver. 1.3.8 - (2026-03-01)
 
 Frosted Glass Dark Lite:
   card-mod-theme: 'Frosted Glass Dark Lite'
@@ -59,13 +59,11 @@ Frosted Glass Dark Lite:
       );
     }
 
-    /* Headings + Glance (kept excluded) */
-    :host(hui-heading-card) ha-card,
-    :host(hui-glance-card) ha-card {
+    /* Headings (kept excluded) */
+    :host(hui-heading-card) ha-card {
       background: none !important;
     }
-    :host(hui-heading-card) ha-card::before,
-    :host(hui-glance-card) ha-card::before {
+    :host(hui-heading-card) ha-card::before {
       content: none !important;
     }
 
@@ -122,7 +120,15 @@ Frosted Glass Dark Lite:
       background: none !important;
     }
 
-    /* (Removed) .bubble-button-card-container styling to avoid conflicts               # 1.2 Glass – matches Light exclusions */
+    /* === Prevent frosted/glass from applying to streamline-card wrapper === */
+    :host(.type-custom-streamline-card) ha-card {
+      background: none !important;
+      box-shadow: none !important;
+      border-radius: 0px !important;
+    }
+    :host(.type-custom-streamline-card) ha-card::before {
+      content: none !important;
+    }
 
   # =========================
   # CARD-MOD-ROOT GLOBAL CSS
@@ -305,6 +311,15 @@ Frosted Glass Dark Lite:
       --text-divider-line-size: 1px;
       --text-divider-color: rgba(234, 235, 238, 1) !important;
     }
+
+  # =========================
+  # CARD-MOD-VIEW (edit-mode empty card fix)
+  # =========================
+  card-mod-view-yaml: |
+    hui-sections-view $ hui-grid-section $ hui-card-edit-mode $: |
+      .card-wrapper {
+        min-height: var(--row-height);
+      }
 
   # =========================
   # TYPOGRAPHY

--- a/themes/Frosted Glass Dark Lite.yaml
+++ b/themes/Frosted Glass Dark Lite.yaml
@@ -1,5 +1,5 @@
 # Frosted Glass Dark Lite
-# ver. 1.3.8 - (2026-03-01)
+# ver. 1.3.9 - (2026-03-01)
 
 Frosted Glass Dark Lite:
   card-mod-theme: 'Frosted Glass Dark Lite'

--- a/themes/Frosted Glass Dark.yaml
+++ b/themes/Frosted Glass Dark.yaml
@@ -1,5 +1,5 @@
 # Frosted Glass Dark
-# ver. 1.3 - (2025-11-24) 
+# ver. 1.3.1 - (2026-02-23) 
 
 Frosted Glass Dark:
   card-mod-theme: 'Frosted Glass Dark'
@@ -154,11 +154,11 @@ Frosted Glass Dark:
       --ha-card-box-shadow: 0 12px 20px rgba(0, 0, 0, 0.28);
       --ha-card-border-width: 0.5px;
       --ha-card-border-color: rgba(234, 235, 238, 0.1);
-      --ha-card-backdrop-filter: blur(10px) saturate(1.2);                               # 1.2 Glass – same engine as Light, tuned for Dark
+      --ha-card-backdrop-filter: blur(10px) saturate(1.2);
 
-      /* Glass system tokens (new, dark-tuned) */
-      --ha-card-glass-tint: rgba(28, 29, 33, 0.18);                                      # 1.2 Glass – global tint layer
-      --ha-card-glass-inset-shadow:                                                      # 1.2 Glass – inner bevel/glow (Liquid Glass inspired)
+      /* Glass system tokens (dark-tuned) */
+      --ha-card-glass-tint: rgba(28, 29, 33, 0.18);
+      --ha-card-glass-inset-shadow:
         3px 3px 0.5px -3.5px rgba(255, 255, 255, 0.15) inset,
         -2px -2px 0.5px -2px rgba(255, 255, 255, 0.1) inset,
         0 0 8px 1px rgba(255, 255, 255, 0.06) inset,
@@ -257,7 +257,7 @@ Frosted Glass Dark:
       --token-font-family-primary: -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
       --token-weight-font-title-card: 500;
       
-      # Additional color variables
+      /* Additional color variables */
       --token-color-red: rgb(var(--token-rgb-red));
       --token-color-green: rgb(var(--token-rgb-green));
       --token-color-blue: rgb(var(--token-rgb-blue));
@@ -284,13 +284,13 @@ Frosted Glass Dark:
       backdrop-filter: blur(8px) saturate(1.1) !important;
       -webkit-backdrop-filter: blur(8px) saturate(1.1) !important;
       background: rgba(25, 28, 45, 0.8) !important;
-      box-shadow: var(--ha-card-glass-inset-shadow) !important;                         # 1.2 Glass – subtle inner edge for consistency
+      box-shadow: var(--ha-card-glass-inset-shadow) !important;
     }
 
     /* CARDS RADIUS */
     ha-card {
       border-radius: var(--token-size-radius-large);
-      border: var(--ha-card-border, var(--ha-card-border-width) solid var(--ha-card-border-color));       # 1.2 Glass – ensure border follows tokens
+      border: var(--ha-card-border, var(--ha-card-border-width) solid var(--ha-card-border-color));
       box-shadow: var(--ha-card-box-shadow);
     }
     ha-card ha-card {
@@ -313,13 +313,30 @@ Frosted Glass Dark:
     }
 
     /* INPUTS */
-    input, ha-textfield, ha-select {
+    input, ha-textfield {
       background: rgba(30, 33, 54, 0.7) !important;
       backdrop-filter: blur(6px) !important;
-      -webkit-backdrop-filter: blur(6px);
+      -webkit-backdrop-filter: blur(6px) !important;
       border-radius: var(--token-size-radius-small);
       border: none !important;
       box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.09) !important;
+    }
+    ha-select {
+      background: rgba(30, 33, 54, 0.7) !important;
+      border-radius: var(--token-size-radius-small);
+      border: none !important;
+      box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.09) !important;
+      position: relative;
+    }
+    ha-select::before {
+      content: '';
+      position: absolute;
+      inset: 0;
+      backdrop-filter: blur(6px);
+      -webkit-backdrop-filter: blur(6px);
+      border-radius: inherit;
+      z-index: -1;
+      pointer-events: none;
     }
 
     /* Custom text divider row size fix */

--- a/themes/Frosted Glass Dark.yaml
+++ b/themes/Frosted Glass Dark.yaml
@@ -1,5 +1,5 @@
 # Frosted Glass Dark
-# ver. 1.3.5 - (2026-02-28)
+# ver. 1.3.6 - (2026-02-28)
 
 Frosted Glass Dark:
   card-mod-theme: 'Frosted Glass Dark'

--- a/themes/Frosted Glass Dark.yaml
+++ b/themes/Frosted Glass Dark.yaml
@@ -10,7 +10,8 @@ Frosted Glass Dark:
   # =========================
   # HEADER (Top Bar)
   # =========================
-  app-header-background-color: 'rgba(30, 30, 30, 0.85)'
+  app-header-backdrop-filter: 'blur(8px) saturate(1.1)'
+  app-header-background-color: 'rgba(30, 30, 30, 0.01)'
   app-header-text-color: 'rgba(240, 243, 255, 0.95)'
   app-header-edit-background-color: 'rgba(30, 33, 54, 0.8)'
   app-header-edit-text-color: 'rgba(234, 235, 238, 0.98)'

--- a/themes/Frosted Glass Dark.yaml
+++ b/themes/Frosted Glass Dark.yaml
@@ -1,5 +1,5 @@
 # Frosted Glass Dark
-# ver. 1.3.1 - (2026-02-23) 
+# ver. 1.3.2 - (2026-02-23) 
 
 Frosted Glass Dark:
   card-mod-theme: 'Frosted Glass Dark'
@@ -10,8 +10,7 @@ Frosted Glass Dark:
   # =========================
   # HEADER (Top Bar)
   # =========================
-  app-header-backdrop-filter: 'blur(8px) saturate(1.1)'
-  app-header-background-color: 'rgba(30, 30, 30, 0.01)'
+  app-header-background-color: 'rgba(30, 30, 30, 0.85)'
   app-header-text-color: 'rgba(240, 243, 255, 0.95)'
   app-header-edit-background-color: 'rgba(30, 33, 54, 0.8)'
   app-header-edit-text-color: 'rgba(234, 235, 238, 0.98)'
@@ -29,8 +28,7 @@ Frosted Glass Dark:
   # =========================
   # DIALOGS
   # =========================
-  ha-dialog-surface-backdrop-filter: 'blur(8px)'                  # 1.2 Glass – same blur as cards
-  ha-dialog-surface-background: 'rgba(30, 30, 30, 0.7)'
+  ha-dialog-surface-background: 'rgba(30, 30, 30, 0.92)'
   dialog-box-shadow: '0 12px 20px rgba(0, 0, 0, 0.25)'
   paper-dialog-background-color: 'rgba(30, 30, 30, 0.7)'
   mdc-dialog-scrim-color: 'rgba(0, 0, 0, 0.8)'
@@ -279,11 +277,9 @@ Frosted Glass Dark:
       --token-color-light-blue: rgb(var(--token-rgb-light-blue));
     }
 
-    /* SIDEBAR BLUR */
+    /* SIDEBAR */
     .mdc-drawer .mdc-drawer__content {
-      backdrop-filter: blur(8px) saturate(1.1) !important;
-      -webkit-backdrop-filter: blur(8px) saturate(1.1) !important;
-      background: rgba(25, 28, 45, 0.8) !important;
+      background: rgba(25, 28, 45, 0.9) !important;
       box-shadow: var(--ha-card-glass-inset-shadow) !important;
     }
 
@@ -304,39 +300,18 @@ Frosted Glass Dark:
 
     /* LABEL BADGE */
     ha-label-badge {
-      --label-badge-background-color: rgba(60, 60, 78, 0.28) !important;
-      backdrop-filter: blur(10px) saturate(1.1) !important;
-      -webkit-backdrop-filter: blur(10px) saturate(1.1) !important;
+      --label-badge-background-color: rgba(60, 60, 78, 0.85) !important;
       --label-badge-text-color: rgba(234, 235, 238, 0.9) !important;
       box-shadow: 0 5px 10px rgba(0, 0, 0, 0.10) !important;
       border: 0.5px solid rgba(234, 235, 238, 0.22) !important;
     }
 
     /* INPUTS */
-    input, ha-textfield {
-      background: rgba(30, 33, 54, 0.7) !important;
-      backdrop-filter: blur(6px) !important;
-      -webkit-backdrop-filter: blur(6px) !important;
-      border-radius: var(--token-size-radius-small);
-      border: none !important;
-      box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.09) !important;
-    }
-    ha-select {
+    input, ha-textfield, ha-select {
       background: rgba(30, 33, 54, 0.7) !important;
       border-radius: var(--token-size-radius-small);
       border: none !important;
       box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.09) !important;
-      position: relative;
-    }
-    ha-select::before {
-      content: '';
-      position: absolute;
-      inset: 0;
-      backdrop-filter: blur(6px);
-      -webkit-backdrop-filter: blur(6px);
-      border-radius: inherit;
-      z-index: -1;
-      pointer-events: none;
     }
 
     /* Custom text divider row size fix */

--- a/themes/Frosted Glass Dark.yaml
+++ b/themes/Frosted Glass Dark.yaml
@@ -1,5 +1,5 @@
 # Frosted Glass Dark
-# ver. 1.3.6 - (2026-02-28)
+# ver. 1.3.7 - (2026-02-28)
 
 Frosted Glass Dark:
   card-mod-theme: 'Frosted Glass Dark'
@@ -10,7 +10,7 @@ Frosted Glass Dark:
   # =========================
   # HEADER (Top Bar)
   # =========================
-  app-header-background-color: 'rgba(30, 30, 30, 0.85)'
+  app-header-background-color: 'rgba(30, 30, 30, 0.01)'
   app-header-text-color: 'rgba(240, 243, 255, 0.95)'
   app-header-edit-background-color: 'rgba(30, 33, 54, 0.8)'
   app-header-edit-text-color: 'rgba(234, 235, 238, 0.98)'
@@ -324,6 +324,21 @@ Frosted Glass Dark:
       --text-divider-font-size: 16px !important;
       --text-divider-line-size: 1px;
       --text-divider-color: rgba(234, 235, 238, 1) !important;
+    }
+
+    /* HEADER frosted glass via ::before (avoids containing block issue with dropdowns) */
+    .header::before {
+      content: '';
+      position: absolute;
+      inset: 0;
+      background: rgba(30, 30, 30, 0.15);
+      backdrop-filter: blur(8px) saturate(1.1);
+      -webkit-backdrop-filter: blur(8px) saturate(1.1);
+      z-index: -1;
+      pointer-events: none;
+    }
+    .edit-mode .header::before {
+      background: rgba(30, 33, 54, 0.8);
     }
 
   # =========================

--- a/themes/Frosted Glass Dark.yaml
+++ b/themes/Frosted Glass Dark.yaml
@@ -10,8 +10,7 @@ Frosted Glass Dark:
   # =========================
   # HEADER (Top Bar)
   # =========================
-  app-header-backdrop-filter: 'blur(8px) saturate(1.1)'
-  app-header-background-color: 'rgba(30, 30, 30, 0.01)'
+  app-header-background-color: 'rgba(30, 30, 30, 0.85)'
   app-header-text-color: 'rgba(240, 243, 255, 0.95)'
   app-header-edit-background-color: 'rgba(30, 33, 54, 0.8)'
   app-header-edit-text-color: 'rgba(234, 235, 238, 0.98)'

--- a/themes/Frosted Glass Dark.yaml
+++ b/themes/Frosted Glass Dark.yaml
@@ -1,5 +1,5 @@
 # Frosted Glass Dark
-# ver. 1.3.2 - (2026-02-23) 
+# ver. 1.3.3 - (2026-02-28) 
 
 Frosted Glass Dark:
   card-mod-theme: 'Frosted Glass Dark'

--- a/themes/Frosted Glass Dark.yaml
+++ b/themes/Frosted Glass Dark.yaml
@@ -1,5 +1,5 @@
 # Frosted Glass Dark
-# ver. 1.3.3 - (2026-02-28) 
+# ver. 1.3.4 - (2026-02-28)
 
 Frosted Glass Dark:
   card-mod-theme: 'Frosted Glass Dark'

--- a/themes/Frosted Glass Dark.yaml
+++ b/themes/Frosted Glass Dark.yaml
@@ -1,5 +1,5 @@
 # Frosted Glass Dark
-# ver. 1.3.4 - (2026-02-28)
+# ver. 1.3.5 - (2026-02-28)
 
 Frosted Glass Dark:
   card-mod-theme: 'Frosted Glass Dark'

--- a/themes/Frosted Glass Dark.yaml
+++ b/themes/Frosted Glass Dark.yaml
@@ -1,5 +1,5 @@
 # Frosted Glass Dark
-# ver. 1.3.8 - (2026-03-01)
+# ver. 1.3.9 - (2026-03-01)
 
 Frosted Glass Dark:
   card-mod-theme: 'Frosted Glass Dark'
@@ -50,8 +50,8 @@ Frosted Glass Dark:
       position: absolute;
       inset: 0;
       background: var(--ha-card-glass-tint, rgba(28, 29, 33, 0.18));                    /* 1.2 Glass – subtle dark tint */
-      backdrop-filter: var(--ha-card-backdrop-filter, blur(10px) saturate(1.2) contrast(0.4));
-      -webkit-backdrop-filter: var(--ha-card-backdrop-filter, blur(10px) saturate(1.2) contrast(0.4));
+      backdrop-filter: var(--ha-card-backdrop-filter, blur(10px) saturate(1.2));
+      -webkit-backdrop-filter: var(--ha-card-backdrop-filter, blur(10px) saturate(1.2));
       z-index: -1;
       pointer-events: none;
       border-radius: inherit;
@@ -160,7 +160,7 @@ Frosted Glass Dark:
       --ha-card-box-shadow: 0 12px 20px rgba(0, 0, 0, 0.28);
       --ha-card-border-width: 0.5px;
       --ha-card-border-color: rgba(234, 235, 238, 0.1);
-      --ha-card-backdrop-filter: blur(10px) saturate(1.2) contrast(0.4);
+      --ha-card-backdrop-filter: blur(10px) saturate(1.2);
 
       /* Glass system tokens (dark-tuned) */
       --ha-card-glass-tint: rgba(28, 29, 33, 0.18);
@@ -465,7 +465,7 @@ Frosted Glass Dark:
   secondary-background-color: 'rgba(30, 33, 54, 0.6)'
   clear-background-color: 'rgba(30, 33, 54, 0.7)'
   card-background-color: 'rgba(30, 30, 30, 0.85)'
-  ha-card-background: 'rgba(30, 30, 30, 0.4)'
+  ha-card-background: 'rgba(30, 30, 30, 0.9)'
   ha-card-border-radius: '18px'
   ha-card-border-color: 'rgba(234, 235, 238, 0.22)'
   ha-card-border-width: '0.5px'

--- a/themes/Frosted Glass Dark.yaml
+++ b/themes/Frosted Glass Dark.yaml
@@ -1,5 +1,5 @@
 # Frosted Glass Dark
-# ver. 1.3.7 - (2026-02-28)
+# ver. 1.3.8 - (2026-03-01)
 
 Frosted Glass Dark:
   card-mod-theme: 'Frosted Glass Dark'
@@ -28,7 +28,7 @@ Frosted Glass Dark:
   # =========================
   # DIALOGS
   # =========================
-  ha-dialog-surface-background: 'rgba(30, 30, 30, 0.92)'
+  ha-dialog-surface-background: 'rgba(30, 30, 30, 0.97)'
   dialog-box-shadow: '0 12px 20px rgba(0, 0, 0, 0.25)'
   paper-dialog-background-color: 'rgba(30, 30, 30, 0.7)'
   mdc-dialog-scrim-color: 'rgba(0, 0, 0, 0.8)'
@@ -50,8 +50,8 @@ Frosted Glass Dark:
       position: absolute;
       inset: 0;
       background: var(--ha-card-glass-tint, rgba(28, 29, 33, 0.18));                    /* 1.2 Glass – subtle dark tint */
-      backdrop-filter: var(--ha-card-backdrop-filter, blur(10px) saturate(1.2));
-      -webkit-backdrop-filter: var(--ha-card-backdrop-filter, blur(10px) saturate(1.2));
+      backdrop-filter: var(--ha-card-backdrop-filter, blur(10px) saturate(1.2) contrast(0.4));
+      -webkit-backdrop-filter: var(--ha-card-backdrop-filter, blur(10px) saturate(1.2) contrast(0.4));
       z-index: -1;
       pointer-events: none;
       border-radius: inherit;
@@ -63,15 +63,13 @@ Frosted Glass Dark:
       );
     }
 
-    /* Headings + Glance (kept excluded) */
-    :host(hui-heading-card) ha-card,
-    :host(hui-glance-card) ha-card {
+    /* Headings (kept excluded) */
+    :host(hui-heading-card) ha-card {
       background: none !important;
       backdrop-filter: none !important;
       -webkit-backdrop-filter: none !important;
     }
-    :host(hui-heading-card) ha-card::before,
-    :host(hui-glance-card) ha-card::before {
+    :host(hui-heading-card) ha-card::before {
       content: none !important;
     }
 
@@ -141,7 +139,17 @@ Frosted Glass Dark:
       -webkit-backdrop-filter: none !important;
     }
 
-    /* (Removed) .bubble-button-card-container styling to avoid conflicts               # 1.2 Glass – matches Light exclusions */
+    /* === Prevent frosted/glass from applying to streamline-card wrapper === */
+    :host(.type-custom-streamline-card) ha-card {
+      background: none !important;
+      backdrop-filter: none !important;
+      -webkit-backdrop-filter: none !important;
+      box-shadow: none !important;
+      border-radius: 0px !important;
+    }
+    :host(.type-custom-streamline-card) ha-card::before {
+      content: none !important;
+    }
 
   # =========================
   # CARD-MOD-ROOT GLOBAL CSS
@@ -152,7 +160,7 @@ Frosted Glass Dark:
       --ha-card-box-shadow: 0 12px 20px rgba(0, 0, 0, 0.28);
       --ha-card-border-width: 0.5px;
       --ha-card-border-color: rgba(234, 235, 238, 0.1);
-      --ha-card-backdrop-filter: blur(10px) saturate(1.2);
+      --ha-card-backdrop-filter: blur(10px) saturate(1.2) contrast(0.4);
 
       /* Glass system tokens (dark-tuned) */
       --ha-card-glass-tint: rgba(28, 29, 33, 0.18);
@@ -342,6 +350,15 @@ Frosted Glass Dark:
     }
 
   # =========================
+  # CARD-MOD-VIEW (edit-mode empty card fix)
+  # =========================
+  card-mod-view-yaml: |
+    hui-sections-view $ hui-grid-section $ hui-card-edit-mode $: |
+      .card-wrapper {
+        min-height: var(--row-height);
+      }
+
+  # =========================
   # TYPOGRAPHY
   # =========================
   ha-font-family-body: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"'
@@ -448,7 +465,7 @@ Frosted Glass Dark:
   secondary-background-color: 'rgba(30, 33, 54, 0.6)'
   clear-background-color: 'rgba(30, 33, 54, 0.7)'
   card-background-color: 'rgba(30, 30, 30, 0.85)'
-  ha-card-background: 'rgba(30, 30, 30, 0.9)'
+  ha-card-background: 'rgba(30, 30, 30, 0.4)'
   ha-card-border-radius: '18px'
   ha-card-border-color: 'rgba(234, 235, 238, 0.22)'
   ha-card-border-width: '0.5px'
@@ -457,6 +474,9 @@ Frosted Glass Dark:
   ha-card-box-shadow: '0 12px 20px rgba(0, 0, 0, 0.28)'
   ha-view-sections-column-gap: '17px'
   ha-view-sections-column-min-width: 320px
+
+  # Control buttons
+  control-button-background-color: 'rgba(173, 176, 184, 0.2)'
 
   # Sliders, toggles, switches
   paper-slider-knob-color: 'rgb(106, 116, 211)'

--- a/themes/Frosted Glass Light Lite.yaml
+++ b/themes/Frosted Glass Light Lite.yaml
@@ -1,5 +1,5 @@
 # Frosted Glass Light Lite
-# ver. 1.3.2 - (2026-02-23)  
+# ver. 1.3.3 - (2026-02-28)  
 
 Frosted Glass Light Lite:
   card-mod-theme: "Frosted Glass Light Lite"

--- a/themes/Frosted Glass Light Lite.yaml
+++ b/themes/Frosted Glass Light Lite.yaml
@@ -1,5 +1,5 @@
 # Frosted Glass Light Lite
-# ver. 1.3 - (2025-11-24)  
+# ver. 1.3.1 - (2026-02-23)  
 
 Frosted Glass Light Lite:
   card-mod-theme: "Frosted Glass Light Lite"
@@ -135,29 +135,15 @@ Frosted Glass Light Lite:
     --ha-card-border-color: rgba(255, 255, 255, 0.3);
 
     /* Glass system tokens (new) */
-    --ha-card-glass-tint: rgba(255, 255, 255, 0.08);                                                      # 1.2 Glass – global tint layer
-    --ha-card-glass-inset-shadow:                                                                         # 1.2 Glass – inner bevel/glow (Liquid Glass inspired)
+    --ha-card-glass-tint: rgba(255, 255, 255, 0.08);                                                      /* 1.2 Glass – global tint layer */
+    --ha-card-glass-inset-shadow:                                                                         /* 1.2 Glass – inner bevel/glow (Liquid Glass inspired) */
       3px 3px 0.5px -3.5px rgba(255, 255, 255, 0.30) inset,
       -2px -2px 0.5px -2px rgba(255, 255, 255, 0.30) inset,
       0 0 8px 1px rgba(255, 255, 255, 0.10) inset,
       0 0 2px 0 rgba(0, 0, 0, 0.10);
-   }
 
-   /* Custom text divider row size fix */
-   custom-text-divider-row .text-divider-content {
-    background: #fff !important; /* or your color */
-    opacity: 1 !important;
-    box-shadow: none !important;
-    border-radius: 10px !important; /* adjust as needed */
-    padding: 0 8px !important;
-    --text-divider-font-size: 16px !important;
-    --text-divider-line-size: 1px;
-    --text-divider-color: rgba(19, 21, 54, 1) !important;
-   }
-
-    
-      # Tokens (used throughout cards/UI)
-      --token-rgb-primary: 106, 116, 211;
+    /* Tokens (used throughout cards/UI) */
+    --token-rgb-primary: 106, 116, 211;
       --token-rgb-black: 0, 0, 0;
       --token-rgb-white: 240, 243, 255;
       --token-rgb-purple: 129, 45, 250;
@@ -249,7 +235,7 @@ Frosted Glass Light Lite:
       --token-font-family-primary: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
       --token-weight-font-title-card: 500;
 
-      # Additional color variables
+      /* Additional color variables */
       --token-color-red: rgb(var(--token-rgb-red));
       --token-color-green: rgb(var(--token-rgb-green));
       --token-color-blue: rgb(var(--token-rgb-blue));
@@ -269,9 +255,21 @@ Frosted Glass Light Lite:
       --token-color-indigo: rgb(var(--token-rgb-indigo));
       --token-color-deep-purple: rgb(var(--token-rgb-deep-purple));
       --token-color-light-blue: rgb(var(--token-rgb-light-blue));
-    }
+   }
 
-    /* SIDEBAR BLUR */
+   /* Custom text divider row size fix */
+   custom-text-divider-row .text-divider-content {
+    background: #fff !important;
+    opacity: 1 !important;
+    box-shadow: none !important;
+    border-radius: 10px !important;
+    padding: 0 8px !important;
+    --text-divider-font-size: 16px !important;
+    --text-divider-line-size: 1px;
+    --text-divider-color: rgba(19, 21, 54, 1) !important;
+   }
+
+    /* SIDEBAR */
     .mdc-drawer .mdc-drawer__content {
       background: rgba(234, 235, 238, 0.7) !important;
       box-shadow: var(--ha-card-glass-inset-shadow) !important;                                          /* 1.2 Glass – subtle inner edge for consistency */
@@ -470,7 +468,7 @@ Frosted Glass Light Lite:
   mush-title-font-weight: '500'
   mush-title-font-size: 'var(--token-size-font-2xl)'
   light-grey-color: 'rgb(103, 104, 119)'
-  mush-rgb-grey: '103, 104, 119)'
+  mush-rgb-grey: '103, 104, 119'
 
   # Misc sizes
   paper-slider-height: '5px'

--- a/themes/Frosted Glass Light Lite.yaml
+++ b/themes/Frosted Glass Light Lite.yaml
@@ -1,5 +1,5 @@
 # Frosted Glass Light Lite
-# ver. 1.3.4 - (2026-02-28)
+# ver. 1.3.5 - (2026-02-28)
 
 Frosted Glass Light Lite:
   card-mod-theme: "Frosted Glass Light Lite"

--- a/themes/Frosted Glass Light Lite.yaml
+++ b/themes/Frosted Glass Light Lite.yaml
@@ -1,5 +1,5 @@
 # Frosted Glass Light Lite
-# ver. 1.3.1 - (2026-02-23)  
+# ver. 1.3.2 - (2026-02-23)  
 
 Frosted Glass Light Lite:
   card-mod-theme: "Frosted Glass Light Lite"

--- a/themes/Frosted Glass Light Lite.yaml
+++ b/themes/Frosted Glass Light Lite.yaml
@@ -1,5 +1,5 @@
 # Frosted Glass Light Lite
-# ver. 1.3.6 - (2026-02-28)
+# ver. 1.3.7 - (2026-02-28)
 
 Frosted Glass Light Lite:
   card-mod-theme: "Frosted Glass Light Lite"

--- a/themes/Frosted Glass Light Lite.yaml
+++ b/themes/Frosted Glass Light Lite.yaml
@@ -1,5 +1,5 @@
 # Frosted Glass Light Lite
-# ver. 1.3.3 - (2026-02-28)  
+# ver. 1.3.4 - (2026-02-28)
 
 Frosted Glass Light Lite:
   card-mod-theme: "Frosted Glass Light Lite"

--- a/themes/Frosted Glass Light Lite.yaml
+++ b/themes/Frosted Glass Light Lite.yaml
@@ -1,5 +1,5 @@
 # Frosted Glass Light Lite
-# ver. 1.3.5 - (2026-02-28)
+# ver. 1.3.6 - (2026-02-28)
 
 Frosted Glass Light Lite:
   card-mod-theme: "Frosted Glass Light Lite"

--- a/themes/Frosted Glass Light Lite.yaml
+++ b/themes/Frosted Glass Light Lite.yaml
@@ -1,5 +1,5 @@
 # Frosted Glass Light Lite
-# ver. 1.3.7 - (2026-02-28)
+# ver. 1.3.8 - (2026-03-01)
 
 Frosted Glass Light Lite:
   card-mod-theme: "Frosted Glass Light Lite"
@@ -61,13 +61,11 @@ Frosted Glass Light Lite:
       );
     }
 
-    /* Headings + Glance (kept as your exclusions) */
-    :host(hui-heading-card) ha-card,
-    :host(hui-glance-card) ha-card {
+    /* Headings (kept excluded) */
+    :host(hui-heading-card) ha-card {
       background: none !important;
     }
-    :host(hui-heading-card) ha-card::before,
-    :host(hui-glance-card) ha-card::before {
+    :host(hui-heading-card) ha-card::before {
       content: none !important;
     }
 
@@ -122,6 +120,16 @@ Frosted Glass Light Lite:
     :host(mushroom-chips-card) ha-card::before {
       content: none !important;
       background: none !important;
+    }
+
+    /* === Prevent frosted/glass from applying to streamline-card wrapper === */
+    :host(.type-custom-streamline-card) ha-card {
+      background: none !important;
+      box-shadow: none !important;
+      border-radius: 0px !important;
+    }
+    :host(.type-custom-streamline-card) ha-card::before {
+      content: none !important;
     }
 
   # =========================
@@ -305,6 +313,15 @@ Frosted Glass Light Lite:
       border: none !important;
       box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.05) !important;
     }
+
+  # =========================
+  # CARD-MOD-VIEW (edit-mode empty card fix)
+  # =========================
+  card-mod-view-yaml: |
+    hui-sections-view $ hui-grid-section $ hui-card-edit-mode $: |
+      .card-wrapper {
+        min-height: var(--row-height);
+      }
 
   # =========================
   # TYPOGRAPHY

--- a/themes/Frosted Glass Light Lite.yaml
+++ b/themes/Frosted Glass Light Lite.yaml
@@ -1,5 +1,5 @@
 # Frosted Glass Light Lite
-# ver. 1.3.8 - (2026-03-01)
+# ver. 1.3.9 - (2026-03-01)
 
 Frosted Glass Light Lite:
   card-mod-theme: "Frosted Glass Light Lite"

--- a/themes/Frosted Glass Light.yaml
+++ b/themes/Frosted Glass Light.yaml
@@ -1,5 +1,5 @@
 # Frosted Glass Light
-# ver. 1.3.6 - (2026-02-28)
+# ver. 1.3.7 - (2026-02-28)
 
 Frosted Glass Light:
   card-mod-theme: "Frosted Glass Light"

--- a/themes/Frosted Glass Light.yaml
+++ b/themes/Frosted Glass Light.yaml
@@ -1,5 +1,5 @@
 # Frosted Glass Light
-# ver. 1.3 - (2025-11-24)  
+# ver. 1.3.1 - (2026-02-23)  
 
 Frosted Glass Light:
   card-mod-theme: "Frosted Glass Light"
@@ -155,32 +155,18 @@ Frosted Glass Light:
     --ha-card-box-shadow: 0 12px 20px rgba(0, 0, 0, 0.15);
     --ha-card-border-width: 0.5px;
     --ha-card-border-color: rgba(255, 255, 255, 0.3);
-    --ha-card-backdrop-filter: blur(8px) saturate(1.2);                                                   # 1.1.9 change - added blur & saturation for badges
+    --ha-card-backdrop-filter: blur(8px) saturate(1.2);
 
-    /* Glass system tokens (new) */
-    --ha-card-glass-tint: rgba(255, 255, 255, 0.08);                                                      # 1.2 Glass – global tint layer
-    --ha-card-glass-inset-shadow:                                                                         # 1.2 Glass – inner bevel/glow (Liquid Glass inspired)
+    /* Glass system tokens */
+    --ha-card-glass-tint: rgba(255, 255, 255, 0.08);
+    --ha-card-glass-inset-shadow:
       3px 3px 0.5px -3.5px rgba(255, 255, 255, 0.30) inset,
       -2px -2px 0.5px -2px rgba(255, 255, 255, 0.30) inset,
       0 0 8px 1px rgba(255, 255, 255, 0.10) inset,
       0 0 2px 0 rgba(0, 0, 0, 0.10);
-   }
 
-   /* Custom text divider row size fix */
-   custom-text-divider-row .text-divider-content {
-    background: #fff !important; /* or your color */
-    opacity: 1 !important;
-    box-shadow: none !important;
-    border-radius: 10px !important; /* adjust as needed */
-    padding: 0 8px !important;
-    --text-divider-font-size: 16px !important;
-    --text-divider-line-size: 1px;
-    --text-divider-color: rgba(19, 21, 54, 1) !important;
-   }
-
-    
-      # Tokens (used throughout cards/UI)
-      --token-rgb-primary: 106, 116, 211;
+    /* Tokens (used throughout cards/UI) */
+    --token-rgb-primary: 106, 116, 211;
       --token-rgb-black: 0, 0, 0;
       --token-rgb-white: 240, 243, 255;
       --token-rgb-purple: 129, 45, 250;
@@ -272,8 +258,8 @@ Frosted Glass Light:
       --token-font-family-primary: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
       --token-weight-font-title-card: 500;
 
-      # Additional color variables
-      --token-color-red: rgb(var(--token-rgb-red));
+    /* Additional color variables */
+    --token-color-red: rgb(var(--token-rgb-red));
       --token-color-green: rgb(var(--token-rgb-green));
       --token-color-blue: rgb(var(--token-rgb-blue));
       --token-color-yellow: rgb(var(--token-rgb-yellow));
@@ -291,21 +277,33 @@ Frosted Glass Light:
       --token-color-blue-grey: rgb(var(--token-rgb-blue-grey));
       --token-color-indigo: rgb(var(--token-rgb-indigo));
       --token-color-deep-purple: rgb(var(--token-rgb-deep-purple));
-      --token-color-light-blue: rgb(var(--token-rgb-light-blue));
-    }
+    --token-color-light-blue: rgb(var(--token-rgb-light-blue));
+   }
+
+   /* Custom text divider row size fix */
+   custom-text-divider-row .text-divider-content {
+    background: #fff !important;
+    opacity: 1 !important;
+    box-shadow: none !important;
+    border-radius: 10px !important;
+    padding: 0 8px !important;
+    --text-divider-font-size: 16px !important;
+    --text-divider-line-size: 1px;
+    --text-divider-color: rgba(19, 21, 54, 1) !important;
+   }
 
     /* SIDEBAR BLUR */
     .mdc-drawer .mdc-drawer__content {
       backdrop-filter: blur(6px) saturate(1.2) !important;
       -webkit-backdrop-filter: blur(6px) saturate(1.2) !important;
       background: rgba(234, 235, 238, 0.7) !important;
-      box-shadow: var(--ha-card-glass-inset-shadow) !important;                                          /* 1.2 Glass – subtle inner edge for consistency */
+      box-shadow: var(--ha-card-glass-inset-shadow) !important;
     }
 
     /* CARDS RADIUS */
     ha-card {
       border-radius: var(--token-size-radius-large);
-      border: var(--ha-card-border, var(--ha-card-border-width) solid var(--ha-card-border-color));       /* 1.2 Glass – ensure border follows tokens */
+      border: var(--ha-card-border, var(--ha-card-border-width) solid var(--ha-card-border-color));
       box-shadow: var(--ha-card-box-shadow);
     }
     ha-card ha-card {
@@ -328,13 +326,30 @@ Frosted Glass Light:
     }
 
     /* INPUTS */
-    input, ha-textfield, ha-select {
+    input, ha-textfield {
       background: rgba(255, 255, 255, 0.7) !important;
       backdrop-filter: blur(6px) !important;
-      -webkit-backdrop-filter: blur(6px);
+      -webkit-backdrop-filter: blur(6px) !important;
       border-radius: var(--token-size-radius-small);
       border: none !important;
       box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.05) !important;
+    }
+    ha-select {
+      background: rgba(255, 255, 255, 0.7) !important;
+      border-radius: var(--token-size-radius-small);
+      border: none !important;
+      box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.05) !important;
+      position: relative;
+    }
+    ha-select::before {
+      content: '';
+      position: absolute;
+      inset: 0;
+      backdrop-filter: blur(6px);
+      -webkit-backdrop-filter: blur(6px);
+      border-radius: inherit;
+      z-index: -1;
+      pointer-events: none;
     }
 
   # =========================

--- a/themes/Frosted Glass Light.yaml
+++ b/themes/Frosted Glass Light.yaml
@@ -10,7 +10,8 @@ Frosted Glass Light:
   # =========================
   # HEADER (Top Bar)
   # =========================
-  app-header-background-color: 'rgba(234, 235, 238, 0.88)'
+  app-header-backdrop-filter: 'blur(6px) saturate(1.2)'
+  app-header-background-color: 'rgba(234, 235, 238, 0.1)'
   app-header-text-color: 'rgba(19, 21, 54, 0.95)'
   app-header-edit-background-color: 'rgba(255, 255, 255, 0.8)'
   app-header-edit-text-color: 'rgba(19, 21, 54, 0.98)'

--- a/themes/Frosted Glass Light.yaml
+++ b/themes/Frosted Glass Light.yaml
@@ -1,5 +1,5 @@
 # Frosted Glass Light
-# ver. 1.3.3 - (2026-02-28)  
+# ver. 1.3.4 - (2026-02-28)
 
 Frosted Glass Light:
   card-mod-theme: "Frosted Glass Light"

--- a/themes/Frosted Glass Light.yaml
+++ b/themes/Frosted Glass Light.yaml
@@ -1,5 +1,5 @@
 # Frosted Glass Light
-# ver. 1.3.4 - (2026-02-28)
+# ver. 1.3.5 - (2026-02-28)
 
 Frosted Glass Light:
   card-mod-theme: "Frosted Glass Light"

--- a/themes/Frosted Glass Light.yaml
+++ b/themes/Frosted Glass Light.yaml
@@ -1,5 +1,5 @@
 # Frosted Glass Light
-# ver. 1.3.5 - (2026-02-28)
+# ver. 1.3.6 - (2026-02-28)
 
 Frosted Glass Light:
   card-mod-theme: "Frosted Glass Light"

--- a/themes/Frosted Glass Light.yaml
+++ b/themes/Frosted Glass Light.yaml
@@ -10,8 +10,7 @@ Frosted Glass Light:
   # =========================
   # HEADER (Top Bar)
   # =========================
-  app-header-backdrop-filter: 'blur(6px) saturate(1.2)'
-  app-header-background-color: 'rgba(234, 235, 238, 0.1)'
+  app-header-background-color: 'rgba(234, 235, 238, 0.88)'
   app-header-text-color: 'rgba(19, 21, 54, 0.95)'
   app-header-edit-background-color: 'rgba(255, 255, 255, 0.8)'
   app-header-edit-text-color: 'rgba(19, 21, 54, 0.98)'

--- a/themes/Frosted Glass Light.yaml
+++ b/themes/Frosted Glass Light.yaml
@@ -1,5 +1,5 @@
 # Frosted Glass Light
-# ver. 1.3.1 - (2026-02-23)  
+# ver. 1.3.2 - (2026-02-23)  
 
 Frosted Glass Light:
   card-mod-theme: "Frosted Glass Light"
@@ -10,8 +10,7 @@ Frosted Glass Light:
   # =========================
   # HEADER (Top Bar)
   # =========================
-  app-header-backdrop-filter: 'blur(6px) saturate(1.2)'
-  app-header-background-color: 'rgba(234, 235, 238, 0.1)'
+  app-header-background-color: 'rgba(234, 235, 238, 0.88)'
   app-header-text-color: 'rgba(19, 21, 54, 0.95)'
   app-header-edit-background-color: 'rgba(255, 255, 255, 0.8)'
   app-header-edit-text-color: 'rgba(19, 21, 54, 0.98)'
@@ -31,8 +30,7 @@ Frosted Glass Light:
   # =========================
   # DIALOGS
   # =========================
-  ha-dialog-surface-backdrop-filter: 'blur(8px)'                                   
-  ha-dialog-surface-background: 'rgba(234, 235, 238, 0.7)'
+  ha-dialog-surface-background: 'rgba(234, 235, 238, 0.94)'
   dialog-box-shadow: '0 12px 20px rgba(0, 0, 0, 0.15)'                                                     # 1.2 Glass – fix: remove stray quotes inside rgba
   paper-dialog-background-color: 'rgba(234, 235, 238, 0.7)'
   mdc-dialog-scrim-color: 'rgba(0, 0, 0, 0.6)'
@@ -292,11 +290,9 @@ Frosted Glass Light:
     --text-divider-color: rgba(19, 21, 54, 1) !important;
    }
 
-    /* SIDEBAR BLUR */
+    /* SIDEBAR */
     .mdc-drawer .mdc-drawer__content {
-      backdrop-filter: blur(6px) saturate(1.2) !important;
-      -webkit-backdrop-filter: blur(6px) saturate(1.2) !important;
-      background: rgba(234, 235, 238, 0.7) !important;
+      background: rgba(234, 235, 238, 0.88) !important;
       box-shadow: var(--ha-card-glass-inset-shadow) !important;
     }
 
@@ -317,39 +313,18 @@ Frosted Glass Light:
 
     /* LABEL BADGE */
     ha-label-badge {
-      --label-badge-background-color: rgba(230, 230, 230, 0.2) !important;
-      backdrop-filter: blur(12px) saturate(1.1) !important;
-      -webkit-backdrop-filter: blur(12px) saturate(1.1) !important;
+      --label-badge-background-color: rgba(230, 230, 230, 0.85) !important;
       --label-badge-text-color: rgba(19, 21, 54, 0.9) !important;
       box-shadow: 0 5px 10px rgba(0, 0, 0, 0.05) !important;
       border: 0.5px solid rgba(255, 255, 255, 0.3) !important;
     }
 
     /* INPUTS */
-    input, ha-textfield {
-      background: rgba(255, 255, 255, 0.7) !important;
-      backdrop-filter: blur(6px) !important;
-      -webkit-backdrop-filter: blur(6px) !important;
-      border-radius: var(--token-size-radius-small);
-      border: none !important;
-      box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.05) !important;
-    }
-    ha-select {
+    input, ha-textfield, ha-select {
       background: rgba(255, 255, 255, 0.7) !important;
       border-radius: var(--token-size-radius-small);
       border: none !important;
       box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.05) !important;
-      position: relative;
-    }
-    ha-select::before {
-      content: '';
-      position: absolute;
-      inset: 0;
-      backdrop-filter: blur(6px);
-      -webkit-backdrop-filter: blur(6px);
-      border-radius: inherit;
-      z-index: -1;
-      pointer-events: none;
     }
 
   # =========================

--- a/themes/Frosted Glass Light.yaml
+++ b/themes/Frosted Glass Light.yaml
@@ -1,5 +1,5 @@
 # Frosted Glass Light
-# ver. 1.3.2 - (2026-02-23)  
+# ver. 1.3.3 - (2026-02-28)  
 
 Frosted Glass Light:
   card-mod-theme: "Frosted Glass Light"

--- a/themes/Frosted Glass Light.yaml
+++ b/themes/Frosted Glass Light.yaml
@@ -1,5 +1,5 @@
 # Frosted Glass Light
-# ver. 1.3.8 - (2026-03-01)
+# ver. 1.3.9 - (2026-03-01)
 
 Frosted Glass Light:
   card-mod-theme: "Frosted Glass Light"
@@ -52,8 +52,8 @@ Frosted Glass Light:
       position: absolute;
       inset: 0;
       background: var(--ha-card-glass-tint, rgba(255, 255, 255, 0.08));                                    /* 1.2 Glass – subtle tint */
-      backdrop-filter: var(--ha-card-backdrop-filter, blur(8px) saturate(1.2) contrast(0.4));
-      -webkit-backdrop-filter: var(--ha-card-backdrop-filter, blur(8px) saturate(1.2) contrast(0.4));
+      backdrop-filter: var(--ha-card-backdrop-filter, blur(8px) saturate(1.2));
+      -webkit-backdrop-filter: var(--ha-card-backdrop-filter, blur(8px) saturate(1.2));
       z-index: -1;
       pointer-events: none;
       border-radius: inherit;
@@ -163,7 +163,7 @@ Frosted Glass Light:
     --ha-card-box-shadow: 0 12px 20px rgba(0, 0, 0, 0.15);
     --ha-card-border-width: 0.5px;
     --ha-card-border-color: rgba(255, 255, 255, 0.3);
-    --ha-card-backdrop-filter: blur(8px) saturate(1.2) contrast(0.4);
+    --ha-card-backdrop-filter: blur(8px) saturate(1.2);
 
     /* Glass system tokens */
     --ha-card-glass-tint: rgba(255, 255, 255, 0.08);
@@ -453,7 +453,7 @@ Frosted Glass Light:
   secondary-background-color: 'rgba(245, 245, 245, 0.5)'
   clear-background-color: 'rgba(254, 244, 242, 0.9)'
   card-background-color: 'rgba(254, 244, 242, 0.9)'
-  ha-card-background: 'rgba(254, 244, 242, 0.4)'
+  ha-card-background: 'rgba(254, 244, 242, 0.9)'
   ha-card-border-radius: '18px'
   ha-card-border-color: 'rgba(255, 255, 255, 0.3)'
   ha-card-border-width: '0.5px'

--- a/themes/Frosted Glass Light.yaml
+++ b/themes/Frosted Glass Light.yaml
@@ -1,5 +1,5 @@
 # Frosted Glass Light
-# ver. 1.3.7 - (2026-02-28)
+# ver. 1.3.8 - (2026-03-01)
 
 Frosted Glass Light:
   card-mod-theme: "Frosted Glass Light"
@@ -52,8 +52,8 @@ Frosted Glass Light:
       position: absolute;
       inset: 0;
       background: var(--ha-card-glass-tint, rgba(255, 255, 255, 0.08));                                    /* 1.2 Glass – subtle tint */
-      backdrop-filter: var(--ha-card-backdrop-filter, blur(8px) saturate(1.2));
-      -webkit-backdrop-filter: var(--ha-card-backdrop-filter, blur(8px) saturate(1.2));
+      backdrop-filter: var(--ha-card-backdrop-filter, blur(8px) saturate(1.2) contrast(0.4));
+      -webkit-backdrop-filter: var(--ha-card-backdrop-filter, blur(8px) saturate(1.2) contrast(0.4));
       z-index: -1;
       pointer-events: none;
       border-radius: inherit;
@@ -65,15 +65,13 @@ Frosted Glass Light:
       );
     }
 
-    /* Headings + Glance (kept as your exclusions) */
-    :host(hui-heading-card) ha-card,
-    :host(hui-glance-card) ha-card {
+    /* Headings (kept excluded) */
+    :host(hui-heading-card) ha-card {
       background: none !important;
       backdrop-filter: none !important;
       -webkit-backdrop-filter: none !important;
     }
-    :host(hui-heading-card) ha-card::before,
-    :host(hui-glance-card) ha-card::before {
+    :host(hui-heading-card) ha-card::before {
       content: none !important;
     }
 
@@ -144,6 +142,18 @@ Frosted Glass Light:
       -webkit-backdrop-filter: none !important;
     }
 
+    /* === Prevent frosted/glass from applying to streamline-card wrapper === */
+    :host(.type-custom-streamline-card) ha-card {
+      background: none !important;
+      backdrop-filter: none !important;
+      -webkit-backdrop-filter: none !important;
+      box-shadow: none !important;
+      border-radius: 0px !important;
+    }
+    :host(.type-custom-streamline-card) ha-card::before {
+      content: none !important;
+    }
+
   # =========================
   # CARD-MOD-ROOT GLOBAL CSS
   # =========================
@@ -153,7 +163,7 @@ Frosted Glass Light:
     --ha-card-box-shadow: 0 12px 20px rgba(0, 0, 0, 0.15);
     --ha-card-border-width: 0.5px;
     --ha-card-border-color: rgba(255, 255, 255, 0.3);
-    --ha-card-backdrop-filter: blur(8px) saturate(1.2);
+    --ha-card-backdrop-filter: blur(8px) saturate(1.2) contrast(0.4);
 
     /* Glass system tokens */
     --ha-card-glass-tint: rgba(255, 255, 255, 0.08);
@@ -328,6 +338,15 @@ Frosted Glass Light:
     }
 
   # =========================
+  # CARD-MOD-VIEW (edit-mode empty card fix)
+  # =========================
+  card-mod-view-yaml: |
+    hui-sections-view $ hui-grid-section $ hui-card-edit-mode $: |
+      .card-wrapper {
+        min-height: var(--row-height);
+      }
+
+  # =========================
   # TYPOGRAPHY
   # =========================
   ha-font-family-body: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"'
@@ -434,7 +453,7 @@ Frosted Glass Light:
   secondary-background-color: 'rgba(245, 245, 245, 0.5)'
   clear-background-color: 'rgba(254, 244, 242, 0.9)'
   card-background-color: 'rgba(254, 244, 242, 0.9)'
-  ha-card-background: 'rgba(254, 244, 242, 0.9)'
+  ha-card-background: 'rgba(254, 244, 242, 0.4)'
   ha-card-border-radius: '18px'
   ha-card-border-color: 'rgba(255, 255, 255, 0.3)'
   ha-card-border-width: '0.5px'

--- a/themes/Frosted Glass Lite.yaml
+++ b/themes/Frosted Glass Lite.yaml
@@ -1,5 +1,5 @@
 # Frosted Glass Light Lite
-# ver. 1.3.1 - (2026-02-23)  
+# ver. 1.3.2 - (2026-02-23)  
 
 Frosted Glass Lite:
   modes:

--- a/themes/Frosted Glass Lite.yaml
+++ b/themes/Frosted Glass Lite.yaml
@@ -1,5 +1,5 @@
 # Frosted Glass Light Lite
-# ver. 1.3.6 - (2026-02-28)
+# ver. 1.3.7 - (2026-02-28)
 
 Frosted Glass Lite:
   modes:

--- a/themes/Frosted Glass Lite.yaml
+++ b/themes/Frosted Glass Lite.yaml
@@ -1,5 +1,5 @@
 # Frosted Glass Light Lite
-# ver. 1.3 - (2025-11-24)  
+# ver. 1.3.1 - (2026-02-23)  
 
 Frosted Glass Lite:
   modes:
@@ -131,32 +131,18 @@ Frosted Glass Lite:
         --ha-card-background: rgba(242, 245, 255, 0.1);
         --ha-card-box-shadow: 0 12px 20px rgba(0, 0, 0, 0.15);
         --ha-card-border-width: 0.5px;
-        --ha-card-border-color: rgba(255, 255, 255, 0.3);                                                # 1.1.9 change - added blur & saturation for badges
+        --ha-card-border-color: rgba(255, 255, 255, 0.3);
 
         /* Glass system tokens (new) */
-        --ha-card-glass-tint: rgba(255, 255, 255, 0.08);                                                      # 1.2 Glass – global tint layer
-        --ha-card-glass-inset-shadow:                                                                         # 1.2 Glass – inner bevel/glow (Liquid Glass inspired)
+        --ha-card-glass-tint: rgba(255, 255, 255, 0.08);                                                      /* 1.2 Glass – global tint layer */
+        --ha-card-glass-inset-shadow:                                                                         /* 1.2 Glass – inner bevel/glow (Liquid Glass inspired) */
           3px 3px 0.5px -3.5px rgba(255, 255, 255, 0.30) inset,
           -2px -2px 0.5px -2px rgba(255, 255, 255, 0.30) inset,
           0 0 8px 1px rgba(255, 255, 255, 0.10) inset,
           0 0 2px 0 rgba(0, 0, 0, 0.10);
-       }
 
-       /* Custom text divider row size fix */
-       custom-text-divider-row .text-divider-content {
-        background: #fff !important; /* or your color */
-        opacity: 1 !important;
-        box-shadow: none !important;
-        border-radius: 10px !important; /* adjust as needed */
-        padding: 0 8px !important;
-        --text-divider-font-size: 16px !important;
-        --text-divider-line-size: 1px;
-        --text-divider-color: rgba(19, 21, 54, 1) !important;
-       }
-
-        
-          # Tokens (used throughout cards/UI)
-          --token-rgb-primary: 106, 116, 211;
+        /* Tokens (used throughout cards/UI) */
+        --token-rgb-primary: 106, 116, 211;
           --token-rgb-black: 0, 0, 0;
           --token-rgb-white: 240, 243, 255;
           --token-rgb-purple: 129, 45, 250;
@@ -248,7 +234,7 @@ Frosted Glass Lite:
           --token-font-family-primary: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
           --token-weight-font-title-card: 500;
 
-          # Additional color variables
+          /* Additional color variables */
           --token-color-red: rgb(var(--token-rgb-red));
           --token-color-green: rgb(var(--token-rgb-green));
           --token-color-blue: rgb(var(--token-rgb-blue));
@@ -268,9 +254,21 @@ Frosted Glass Lite:
           --token-color-indigo: rgb(var(--token-rgb-indigo));
           --token-color-deep-purple: rgb(var(--token-rgb-deep-purple));
           --token-color-light-blue: rgb(var(--token-rgb-light-blue));
-        }
+       }
 
-        /* SIDEBAR BLUR */
+       /* Custom text divider row size fix */
+       custom-text-divider-row .text-divider-content {
+        background: #fff !important;
+        opacity: 1 !important;
+        box-shadow: none !important;
+        border-radius: 10px !important;
+        padding: 0 8px !important;
+        --text-divider-font-size: 16px !important;
+        --text-divider-line-size: 1px;
+        --text-divider-color: rgba(19, 21, 54, 1) !important;
+       }
+
+        /* SIDEBAR */
         .mdc-drawer .mdc-drawer__content {
           background: rgba(234, 235, 238, 0.7) !important;
           box-shadow: var(--ha-card-glass-inset-shadow) !important;                                          /* 1.2 Glass – subtle inner edge for consistency */
@@ -470,7 +468,7 @@ Frosted Glass Lite:
       mush-title-font-weight: '500'
       mush-title-font-size: 'var(--token-size-font-2xl)'
       light-grey-color: 'rgb(103, 104, 119)'
-      mush-rgb-grey: '103, 104, 119)'
+      mush-rgb-grey: '103, 104, 119'
 
       # Misc sizes
       paper-slider-height: '5px'
@@ -606,8 +604,8 @@ Frosted Glass Lite:
           --ha-card-border-color: rgba(234, 235, 238, 0.1);
 
           /* Glass system tokens (new, dark-tuned) */
-          --ha-card-glass-tint: rgba(28, 29, 33, 0.18);                                      # 1.2 Glass – global tint layer
-          --ha-card-glass-inset-shadow:                                                      # 1.2 Glass – inner bevel/glow (Liquid Glass inspired)
+          --ha-card-glass-tint: rgba(28, 29, 33, 0.18);                                      /* 1.2 Glass – global tint layer */
+          --ha-card-glass-inset-shadow:                                                      /* 1.2 Glass – inner bevel/glow (Liquid Glass inspired) */
             3px 3px 0.5px -3.5px rgba(255, 255, 255, 0.15) inset,
             -2px -2px 0.5px -2px rgba(255, 255, 255, 0.1) inset,
             0 0 8px 1px rgba(255, 255, 255, 0.06) inset,
@@ -705,8 +703,8 @@ Frosted Glass Lite:
           --token-opacity-ripple-hover: 0.1;
           --token-font-family-primary: -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
           --token-weight-font-title-card: 500;
-          
-          # Additional color variables
+
+          /* Additional color variables */
           --token-color-red: rgb(var(--token-rgb-red));
           --token-color-green: rgb(var(--token-rgb-green));
           --token-color-blue: rgb(var(--token-rgb-blue));
@@ -731,13 +729,13 @@ Frosted Glass Lite:
         /* SIDEBAR BLUR */
         .mdc-drawer .mdc-drawer__content {
           background: rgba(25, 28, 45, 0.8) !important;
-          box-shadow: var(--ha-card-glass-inset-shadow) !important;                         # 1.2 Glass – subtle inner edge for consistency
+          box-shadow: var(--ha-card-glass-inset-shadow) !important;
         }
 
         /* CARDS RADIUS */
         ha-card {
           border-radius: var(--token-size-radius-large);
-          border: var(--ha-card-border, var(--ha-card-border-width) solid var(--ha-card-border-color));       # 1.2 Glass – ensure border follows tokens
+          border: var(--ha-card-border, var(--ha-card-border-width) solid var(--ha-card-border-color));
           box-shadow: var(--ha-card-box-shadow);
         }
         ha-card ha-card {

--- a/themes/Frosted Glass Lite.yaml
+++ b/themes/Frosted Glass Lite.yaml
@@ -1,5 +1,5 @@
 # Frosted Glass Light Lite
-# ver. 1.3.3 - (2026-02-28)  
+# ver. 1.3.4 - (2026-02-28)
 
 Frosted Glass Lite:
   modes:

--- a/themes/Frosted Glass Lite.yaml
+++ b/themes/Frosted Glass Lite.yaml
@@ -1,5 +1,5 @@
 # Frosted Glass Light Lite
-# ver. 1.3.4 - (2026-02-28)
+# ver. 1.3.5 - (2026-02-28)
 
 Frosted Glass Lite:
   modes:

--- a/themes/Frosted Glass Lite.yaml
+++ b/themes/Frosted Glass Lite.yaml
@@ -1,5 +1,5 @@
 # Frosted Glass Light Lite
-# ver. 1.3.5 - (2026-02-28)
+# ver. 1.3.6 - (2026-02-28)
 
 Frosted Glass Lite:
   modes:

--- a/themes/Frosted Glass Lite.yaml
+++ b/themes/Frosted Glass Lite.yaml
@@ -1,5 +1,5 @@
 # Frosted Glass Light Lite
-# ver. 1.3.2 - (2026-02-23)  
+# ver. 1.3.3 - (2026-02-28)  
 
 Frosted Glass Lite:
   modes:

--- a/themes/Frosted Glass Lite.yaml
+++ b/themes/Frosted Glass Lite.yaml
@@ -1,5 +1,5 @@
 # Frosted Glass Light Lite
-# ver. 1.3.7 - (2026-02-28)
+# ver. 1.3.8 - (2026-03-01)
 
 Frosted Glass Lite:
   modes:
@@ -60,13 +60,11 @@ Frosted Glass Lite:
           );
         }
 
-        /* Headings + Glance (kept as your exclusions) */
-        :host(hui-heading-card) ha-card,
-        :host(hui-glance-card) ha-card {
+        /* Headings (kept excluded) */
+        :host(hui-heading-card) ha-card {
           background: none !important;
         }
-        :host(hui-heading-card) ha-card::before,
-        :host(hui-glance-card) ha-card::before {
+        :host(hui-heading-card) ha-card::before {
           content: none !important;
         }
 
@@ -121,6 +119,16 @@ Frosted Glass Lite:
         :host(mushroom-chips-card) ha-card::before {
           content: none !important;
           background: none !important;
+        }
+
+        /* === Prevent frosted/glass from applying to streamline-card wrapper === */
+        :host(.type-custom-streamline-card) ha-card {
+          background: none !important;
+          box-shadow: none !important;
+          border-radius: 0px !important;
+        }
+        :host(.type-custom-streamline-card) ha-card::before {
+          content: none !important;
         }
 
       # =========================
@@ -304,6 +312,15 @@ Frosted Glass Lite:
           border: none !important;
           box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.05) !important;
         }
+
+      # =========================
+      # CARD-MOD-VIEW (edit-mode empty card fix)
+      # =========================
+      card-mod-view-yaml: |
+        hui-sections-view $ hui-grid-section $ hui-card-edit-mode $: |
+          .card-wrapper {
+            min-height: var(--row-height);
+          }
 
       # =========================
       # TYPOGRAPHY
@@ -529,13 +546,11 @@ Frosted Glass Lite:
           );
         }
 
-        /* Headings + Glance (kept excluded) */
-        :host(hui-heading-card) ha-card,
-        :host(hui-glance-card) ha-card {
+        /* Headings (kept excluded) */
+        :host(hui-heading-card) ha-card {
           background: none !important;
         }
-        :host(hui-heading-card) ha-card::before,
-        :host(hui-glance-card) ha-card::before {
+        :host(hui-heading-card) ha-card::before {
           content: none !important;
         }
 
@@ -591,7 +606,15 @@ Frosted Glass Lite:
           background: none !important;
         }
 
-        /* (Removed) .bubble-button-card-container styling to avoid conflicts               # 1.2 Glass – matches Light exclusions */
+        /* === Prevent frosted/glass from applying to streamline-card wrapper === */
+        :host(.type-custom-streamline-card) ha-card {
+          background: none !important;
+          box-shadow: none !important;
+          border-radius: 0px !important;
+        }
+        :host(.type-custom-streamline-card) ha-card::before {
+          content: none !important;
+        }
 
       # =========================
       # CARD-MOD-ROOT GLOBAL CSS
@@ -774,6 +797,15 @@ Frosted Glass Lite:
           --text-divider-line-size: 1px;
           --text-divider-color: rgba(234, 235, 238, 1) !important;
         }
+
+      # =========================
+      # CARD-MOD-VIEW (edit-mode empty card fix)
+      # =========================
+      card-mod-view-yaml: |
+        hui-sections-view $ hui-grid-section $ hui-card-edit-mode $: |
+          .card-wrapper {
+            min-height: var(--row-height);
+          }
 
       # =========================
       # TYPOGRAPHY

--- a/themes/Frosted Glass Lite.yaml
+++ b/themes/Frosted Glass Lite.yaml
@@ -1,5 +1,5 @@
 # Frosted Glass Light Lite
-# ver. 1.3.8 - (2026-03-01)
+# ver. 1.3.9 - (2026-03-01)
 
 Frosted Glass Lite:
   modes:

--- a/themes/Frosted Glass.yaml
+++ b/themes/Frosted Glass.yaml
@@ -9,7 +9,8 @@ Frosted Glass:
       # =========================
       # HEADER (Top Bar)
       # =========================
-      app-header-background-color: 'rgba(234, 235, 238, 0.88)'
+      app-header-backdrop-filter: 'blur(6px) saturate(1.2)'
+      app-header-background-color: 'rgba(234, 235, 238, 0.1)'
       app-header-text-color: 'rgba(19, 21, 54, 0.95)'
       app-header-edit-background-color: 'rgba(255, 255, 255, 0.8)'
       app-header-edit-text-color: 'rgba(19, 21, 54, 0.98)'
@@ -500,7 +501,8 @@ Frosted Glass:
       # =========================
       # HEADER (Top Bar)
       # =========================
-      app-header-background-color: 'rgba(30, 30, 30, 0.85)'
+      app-header-backdrop-filter: 'blur(8px) saturate(1.1)'
+      app-header-background-color: 'rgba(30, 30, 30, 0.01)'
       app-header-text-color: 'rgba(240, 243, 255, 0.95)'
       app-header-edit-background-color: 'rgba(30, 33, 54, 0.8)'
       app-header-edit-text-color: 'rgba(234, 235, 238, 0.98)'

--- a/themes/Frosted Glass.yaml
+++ b/themes/Frosted Glass.yaml
@@ -1,5 +1,5 @@
 # Frosted Glass
-# ver. 1.3.4 - (2026-02-28)
+# ver. 1.3.5 - (2026-02-28)
 
 Frosted Glass:
   modes:

--- a/themes/Frosted Glass.yaml
+++ b/themes/Frosted Glass.yaml
@@ -1,5 +1,5 @@
 # Frosted Glass
-# ver. 1.3.3 - (2026-02-28) 
+# ver. 1.3.4 - (2026-02-28)
 
 Frosted Glass:
   modes:

--- a/themes/Frosted Glass.yaml
+++ b/themes/Frosted Glass.yaml
@@ -1,5 +1,5 @@
 # Frosted Glass
-# ver. 1.3.1 - (2026-02-23) 
+# ver. 1.3.2 - (2026-02-23) 
 
 Frosted Glass:
   modes:
@@ -9,8 +9,7 @@ Frosted Glass:
       # =========================
       # HEADER (Top Bar)
       # =========================
-      app-header-backdrop-filter: 'blur(6px) saturate(1.2)'
-      app-header-background-color: 'rgba(234, 235, 238, 0.1)'
+      app-header-background-color: 'rgba(234, 235, 238, 0.88)'
       app-header-text-color: 'rgba(19, 21, 54, 0.95)'
       app-header-edit-background-color: 'rgba(255, 255, 255, 0.8)'
       app-header-edit-text-color: 'rgba(19, 21, 54, 0.98)'
@@ -30,8 +29,7 @@ Frosted Glass:
       # =========================
       # DIALOGS
       # =========================
-      ha-dialog-surface-backdrop-filter: 'blur(8px)'                                   
-      ha-dialog-surface-background: 'rgba(234, 235, 238, 0.7)'
+      ha-dialog-surface-background: 'rgba(234, 235, 238, 0.94)'
       dialog-box-shadow: '0 12px 20px rgba(0, 0, 0, 0.15)'                                                     # 1.2 Glass – fix: remove stray quotes inside rgba
       paper-dialog-background-color: 'rgba(234, 235, 238, 0.7)'
       mdc-dialog-scrim-color: 'rgba(0, 0, 0, 0.6)'
@@ -291,11 +289,9 @@ Frosted Glass:
         --text-divider-color: rgba(19, 21, 54, 1) !important;
        }
 
-        /* SIDEBAR BLUR */
+        /* SIDEBAR */
         .mdc-drawer .mdc-drawer__content {
-          backdrop-filter: blur(6px) saturate(1.2) !important;
-          -webkit-backdrop-filter: blur(6px) saturate(1.2) !important;
-          background: rgba(234, 235, 238, 0.7) !important;
+          background: rgba(234, 235, 238, 0.88) !important;
           box-shadow: var(--ha-card-glass-inset-shadow) !important;
         }
 
@@ -316,39 +312,18 @@ Frosted Glass:
 
         /* LABEL BADGE */
         ha-label-badge {
-          --label-badge-background-color: rgba(230, 230, 230, 0.2) !important;
-          backdrop-filter: blur(12px) saturate(1.1) !important;
-          -webkit-backdrop-filter: blur(12px) saturate(1.1) !important;
+          --label-badge-background-color: rgba(230, 230, 230, 0.85) !important;
           --label-badge-text-color: rgba(19, 21, 54, 0.9) !important;
           box-shadow: 0 5px 10px rgba(0, 0, 0, 0.05) !important;
           border: 0.5px solid rgba(255, 255, 255, 0.3) !important;
         }
 
         /* INPUTS */
-        input, ha-textfield {
-          background: rgba(255, 255, 255, 0.7) !important;
-          backdrop-filter: blur(6px) !important;
-          -webkit-backdrop-filter: blur(6px) !important;
-          border-radius: var(--token-size-radius-small);
-          border: none !important;
-          box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.05) !important;
-        }
-        ha-select {
+        input, ha-textfield, ha-select {
           background: rgba(255, 255, 255, 0.7) !important;
           border-radius: var(--token-size-radius-small);
           border: none !important;
           box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.05) !important;
-          position: relative;
-        }
-        ha-select::before {
-          content: '';
-          position: absolute;
-          inset: 0;
-          backdrop-filter: blur(6px);
-          -webkit-backdrop-filter: blur(6px);
-          border-radius: inherit;
-          z-index: -1;
-          pointer-events: none;
         }
 
       # =========================
@@ -525,8 +500,7 @@ Frosted Glass:
       # =========================
       # HEADER (Top Bar)
       # =========================
-      app-header-backdrop-filter: 'blur(8px) saturate(1.1)'
-      app-header-background-color: 'rgba(30, 30, 30, 0.01)'
+      app-header-background-color: 'rgba(30, 30, 30, 0.85)'
       app-header-text-color: 'rgba(240, 243, 255, 0.95)'
       app-header-edit-background-color: 'rgba(30, 33, 54, 0.8)'
       app-header-edit-text-color: 'rgba(234, 235, 238, 0.98)'
@@ -544,8 +518,7 @@ Frosted Glass:
       # =========================
       # DIALOGS
       # =========================
-      ha-dialog-surface-backdrop-filter: 'blur(8px)'                  # 1.2 Glass – same blur as cards
-      ha-dialog-surface-background: 'rgba(30, 30, 30, 0.7)'
+      ha-dialog-surface-background: 'rgba(30, 30, 30, 0.92)'
       dialog-box-shadow: '0 12px 20px rgba(0, 0, 0, 0.25)'
       paper-dialog-background-color: 'rgba(30, 30, 30, 0.7)'
       mdc-dialog-scrim-color: 'rgba(0, 0, 0, 0.8)'
@@ -794,11 +767,9 @@ Frosted Glass:
           --token-color-light-blue: rgb(var(--token-rgb-light-blue));
         }
 
-        /* SIDEBAR BLUR */
+        /* SIDEBAR */
         .mdc-drawer .mdc-drawer__content {
-          backdrop-filter: blur(8px) saturate(1.1) !important;
-          -webkit-backdrop-filter: blur(8px) saturate(1.1) !important;
-          background: rgba(25, 28, 45, 0.8) !important;
+          background: rgba(25, 28, 45, 0.9) !important;
           box-shadow: var(--ha-card-glass-inset-shadow) !important;
         }
 
@@ -819,39 +790,18 @@ Frosted Glass:
 
         /* LABEL BADGE */
         ha-label-badge {
-          --label-badge-background-color: rgba(60, 60, 78, 0.28) !important;
-          backdrop-filter: blur(10px) saturate(1.1) !important;
-          -webkit-backdrop-filter: blur(10px) saturate(1.1) !important;
+          --label-badge-background-color: rgba(60, 60, 78, 0.85) !important;
           --label-badge-text-color: rgba(234, 235, 238, 0.9) !important;
           box-shadow: 0 5px 10px rgba(0, 0, 0, 0.10) !important;
           border: 0.5px solid rgba(234, 235, 238, 0.22) !important;
         }
 
         /* INPUTS */
-        input, ha-textfield {
-          background: rgba(30, 33, 54, 0.7) !important;
-          backdrop-filter: blur(6px) !important;
-          -webkit-backdrop-filter: blur(6px) !important;
-          border-radius: var(--token-size-radius-small);
-          border: none !important;
-          box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.09) !important;
-        }
-        ha-select {
+        input, ha-textfield, ha-select {
           background: rgba(30, 33, 54, 0.7) !important;
           border-radius: var(--token-size-radius-small);
           border: none !important;
           box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.09) !important;
-          position: relative;
-        }
-        ha-select::before {
-          content: '';
-          position: absolute;
-          inset: 0;
-          backdrop-filter: blur(6px);
-          -webkit-backdrop-filter: blur(6px);
-          border-radius: inherit;
-          z-index: -1;
-          pointer-events: none;
         }
 
         /* Custom text divider row size fix */

--- a/themes/Frosted Glass.yaml
+++ b/themes/Frosted Glass.yaml
@@ -1,5 +1,5 @@
 # Frosted Glass
-# ver. 1.3 - (2025-11-24) 
+# ver. 1.3.1 - (2026-02-23) 
 
 Frosted Glass:
   modes:
@@ -154,32 +154,18 @@ Frosted Glass:
         --ha-card-box-shadow: 0 12px 20px rgba(0, 0, 0, 0.15);
         --ha-card-border-width: 0.5px;
         --ha-card-border-color: rgba(255, 255, 255, 0.3);
-        --ha-card-backdrop-filter: blur(8px) saturate(1.2);                                                   # 1.1.9 change - added blur & saturation for badges
+        --ha-card-backdrop-filter: blur(8px) saturate(1.2);
 
-        /* Glass system tokens (new) */
-        --ha-card-glass-tint: rgba(255, 255, 255, 0.08);                                                      # 1.2 Glass – global tint layer
-        --ha-card-glass-inset-shadow:                                                                         # 1.2 Glass – inner bevel/glow (Liquid Glass inspired)
+        /* Glass system tokens */
+        --ha-card-glass-tint: rgba(255, 255, 255, 0.08);
+        --ha-card-glass-inset-shadow:
           3px 3px 0.5px -3.5px rgba(255, 255, 255, 0.30) inset,
           -2px -2px 0.5px -2px rgba(255, 255, 255, 0.30) inset,
           0 0 8px 1px rgba(255, 255, 255, 0.10) inset,
           0 0 2px 0 rgba(0, 0, 0, 0.10);
-       }
 
-       /* Custom text divider row size fix */
-       custom-text-divider-row .text-divider-content {
-        background: #fff !important; /* or your color */
-        opacity: 1 !important;
-        box-shadow: none !important;
-        border-radius: 10px !important; /* adjust as needed */
-        padding: 0 8px !important;
-        --text-divider-font-size: 16px !important;
-        --text-divider-line-size: 1px;
-        --text-divider-color: rgba(19, 21, 54, 1) !important;
-       }
-
-        
-          # Tokens (used throughout cards/UI)
-          --token-rgb-primary: 106, 116, 211;
+        /* Tokens (used throughout cards/UI) */
+        --token-rgb-primary: 106, 116, 211;
           --token-rgb-black: 0, 0, 0;
           --token-rgb-white: 240, 243, 255;
           --token-rgb-purple: 129, 45, 250;
@@ -271,7 +257,7 @@ Frosted Glass:
           --token-font-family-primary: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
           --token-weight-font-title-card: 500;
 
-          # Additional color variables
+          /* Additional color variables */
           --token-color-red: rgb(var(--token-rgb-red));
           --token-color-green: rgb(var(--token-rgb-green));
           --token-color-blue: rgb(var(--token-rgb-blue));
@@ -291,20 +277,32 @@ Frosted Glass:
           --token-color-indigo: rgb(var(--token-rgb-indigo));
           --token-color-deep-purple: rgb(var(--token-rgb-deep-purple));
           --token-color-light-blue: rgb(var(--token-rgb-light-blue));
-        }
+       }
+
+       /* Custom text divider row size fix */
+       custom-text-divider-row .text-divider-content {
+        background: #fff !important;
+        opacity: 1 !important;
+        box-shadow: none !important;
+        border-radius: 10px !important;
+        padding: 0 8px !important;
+        --text-divider-font-size: 16px !important;
+        --text-divider-line-size: 1px;
+        --text-divider-color: rgba(19, 21, 54, 1) !important;
+       }
 
         /* SIDEBAR BLUR */
         .mdc-drawer .mdc-drawer__content {
           backdrop-filter: blur(6px) saturate(1.2) !important;
           -webkit-backdrop-filter: blur(6px) saturate(1.2) !important;
           background: rgba(234, 235, 238, 0.7) !important;
-          box-shadow: var(--ha-card-glass-inset-shadow) !important;                                          /* 1.2 Glass – subtle inner edge for consistency */
+          box-shadow: var(--ha-card-glass-inset-shadow) !important;
         }
 
         /* CARDS RADIUS */
         ha-card {
           border-radius: var(--token-size-radius-large);
-          border: var(--ha-card-border, var(--ha-card-border-width) solid var(--ha-card-border-color));       /* 1.2 Glass – ensure border follows tokens */
+          border: var(--ha-card-border, var(--ha-card-border-width) solid var(--ha-card-border-color));
           box-shadow: var(--ha-card-box-shadow);
         }
         ha-card ha-card {
@@ -327,13 +325,30 @@ Frosted Glass:
         }
 
         /* INPUTS */
-        input, ha-textfield, ha-select {
+        input, ha-textfield {
           background: rgba(255, 255, 255, 0.7) !important;
           backdrop-filter: blur(6px) !important;
-          -webkit-backdrop-filter: blur(6px);
+          -webkit-backdrop-filter: blur(6px) !important;
           border-radius: var(--token-size-radius-small);
           border: none !important;
           box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.05) !important;
+        }
+        ha-select {
+          background: rgba(255, 255, 255, 0.7) !important;
+          border-radius: var(--token-size-radius-small);
+          border: none !important;
+          box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.05) !important;
+          position: relative;
+        }
+        ha-select::before {
+          content: '';
+          position: absolute;
+          inset: 0;
+          backdrop-filter: blur(6px);
+          -webkit-backdrop-filter: blur(6px);
+          border-radius: inherit;
+          z-index: -1;
+          pointer-events: none;
         }
 
       # =========================
@@ -498,7 +513,7 @@ Frosted Glass:
       mush-title-font-weight: '500'
       mush-title-font-size: 'var(--token-size-font-2xl)'
       light-grey-color: 'rgb(103, 104, 119)'
-      mush-rgb-grey: '103, 104, 119)'
+      mush-rgb-grey: '103, 104, 119'
 
       # Misc sizes
       paper-slider-height: '5px'
@@ -654,11 +669,11 @@ Frosted Glass:
           --ha-card-box-shadow: 0 12px 20px rgba(0, 0, 0, 0.28);
           --ha-card-border-width: 0.5px;
           --ha-card-border-color: rgba(234, 235, 238, 0.1);
-          --ha-card-backdrop-filter: blur(10px) saturate(1.2);                               # 1.2 Glass – same engine as Light, tuned for Dark
+          --ha-card-backdrop-filter: blur(10px) saturate(1.2);
 
-          /* Glass system tokens (new, dark-tuned) */
-          --ha-card-glass-tint: rgba(28, 29, 33, 0.18);                                      # 1.2 Glass – global tint layer
-          --ha-card-glass-inset-shadow:                                                      # 1.2 Glass – inner bevel/glow (Liquid Glass inspired)
+          /* Glass system tokens (dark-tuned) */
+          --ha-card-glass-tint: rgba(28, 29, 33, 0.18);
+          --ha-card-glass-inset-shadow:
             3px 3px 0.5px -3.5px rgba(255, 255, 255, 0.15) inset,
             -2px -2px 0.5px -2px rgba(255, 255, 255, 0.1) inset,
             0 0 8px 1px rgba(255, 255, 255, 0.06) inset,
@@ -757,7 +772,7 @@ Frosted Glass:
           --token-font-family-primary: -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
           --token-weight-font-title-card: 500;
           
-          # Additional color variables
+          /* Additional color variables */
           --token-color-red: rgb(var(--token-rgb-red));
           --token-color-green: rgb(var(--token-rgb-green));
           --token-color-blue: rgb(var(--token-rgb-blue));
@@ -784,13 +799,13 @@ Frosted Glass:
           backdrop-filter: blur(8px) saturate(1.1) !important;
           -webkit-backdrop-filter: blur(8px) saturate(1.1) !important;
           background: rgba(25, 28, 45, 0.8) !important;
-          box-shadow: var(--ha-card-glass-inset-shadow) !important;                         # 1.2 Glass – subtle inner edge for consistency
+          box-shadow: var(--ha-card-glass-inset-shadow) !important;
         }
 
         /* CARDS RADIUS */
         ha-card {
           border-radius: var(--token-size-radius-large);
-          border: var(--ha-card-border, var(--ha-card-border-width) solid var(--ha-card-border-color));       # 1.2 Glass – ensure border follows tokens
+          border: var(--ha-card-border, var(--ha-card-border-width) solid var(--ha-card-border-color));
           box-shadow: var(--ha-card-box-shadow);
         }
         ha-card ha-card {
@@ -813,13 +828,30 @@ Frosted Glass:
         }
 
         /* INPUTS */
-        input, ha-textfield, ha-select {
+        input, ha-textfield {
           background: rgba(30, 33, 54, 0.7) !important;
           backdrop-filter: blur(6px) !important;
-          -webkit-backdrop-filter: blur(6px);
+          -webkit-backdrop-filter: blur(6px) !important;
           border-radius: var(--token-size-radius-small);
           border: none !important;
           box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.09) !important;
+        }
+        ha-select {
+          background: rgba(30, 33, 54, 0.7) !important;
+          border-radius: var(--token-size-radius-small);
+          border: none !important;
+          box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.09) !important;
+          position: relative;
+        }
+        ha-select::before {
+          content: '';
+          position: absolute;
+          inset: 0;
+          backdrop-filter: blur(6px);
+          -webkit-backdrop-filter: blur(6px);
+          border-radius: inherit;
+          z-index: -1;
+          pointer-events: none;
         }
 
         /* Custom text divider row size fix */

--- a/themes/Frosted Glass.yaml
+++ b/themes/Frosted Glass.yaml
@@ -1,5 +1,5 @@
 # Frosted Glass
-# ver. 1.3.5 - (2026-02-28)
+# ver. 1.3.6 - (2026-02-28)
 
 Frosted Glass:
   modes:

--- a/themes/Frosted Glass.yaml
+++ b/themes/Frosted Glass.yaml
@@ -1,5 +1,5 @@
 # Frosted Glass
-# ver. 1.3.6 - (2026-02-28)
+# ver. 1.3.7 - (2026-02-28)
 
 Frosted Glass:
   modes:
@@ -500,7 +500,7 @@ Frosted Glass:
       # =========================
       # HEADER (Top Bar)
       # =========================
-      app-header-background-color: 'rgba(30, 30, 30, 0.85)'
+      app-header-background-color: 'rgba(30, 30, 30, 0.01)'
       app-header-text-color: 'rgba(240, 243, 255, 0.95)'
       app-header-edit-background-color: 'rgba(30, 33, 54, 0.8)'
       app-header-edit-text-color: 'rgba(234, 235, 238, 0.98)'
@@ -814,6 +814,21 @@ Frosted Glass:
           --text-divider-font-size: 16px !important;
           --text-divider-line-size: 1px;
           --text-divider-color: rgba(234, 235, 238, 1) !important;
+        }
+
+        /* HEADER frosted glass via ::before (avoids containing block issue with dropdowns) */
+        .header::before {
+          content: '';
+          position: absolute;
+          inset: 0;
+          background: rgba(30, 30, 30, 0.15);
+          backdrop-filter: blur(8px) saturate(1.1);
+          -webkit-backdrop-filter: blur(8px) saturate(1.1);
+          z-index: -1;
+          pointer-events: none;
+        }
+        .edit-mode .header::before {
+          background: rgba(30, 33, 54, 0.8);
         }
 
       # =========================

--- a/themes/Frosted Glass.yaml
+++ b/themes/Frosted Glass.yaml
@@ -9,8 +9,7 @@ Frosted Glass:
       # =========================
       # HEADER (Top Bar)
       # =========================
-      app-header-backdrop-filter: 'blur(6px) saturate(1.2)'
-      app-header-background-color: 'rgba(234, 235, 238, 0.1)'
+      app-header-background-color: 'rgba(234, 235, 238, 0.88)'
       app-header-text-color: 'rgba(19, 21, 54, 0.95)'
       app-header-edit-background-color: 'rgba(255, 255, 255, 0.8)'
       app-header-edit-text-color: 'rgba(19, 21, 54, 0.98)'
@@ -501,8 +500,7 @@ Frosted Glass:
       # =========================
       # HEADER (Top Bar)
       # =========================
-      app-header-backdrop-filter: 'blur(8px) saturate(1.1)'
-      app-header-background-color: 'rgba(30, 30, 30, 0.01)'
+      app-header-background-color: 'rgba(30, 30, 30, 0.85)'
       app-header-text-color: 'rgba(240, 243, 255, 0.95)'
       app-header-edit-background-color: 'rgba(30, 33, 54, 0.8)'
       app-header-edit-text-color: 'rgba(234, 235, 238, 0.98)'

--- a/themes/Frosted Glass.yaml
+++ b/themes/Frosted Glass.yaml
@@ -1,5 +1,5 @@
 # Frosted Glass
-# ver. 1.3.2 - (2026-02-23) 
+# ver. 1.3.3 - (2026-02-28) 
 
 Frosted Glass:
   modes:

--- a/themes/Frosted Glass.yaml
+++ b/themes/Frosted Glass.yaml
@@ -1,5 +1,5 @@
 # Frosted Glass
-# ver. 1.3.7 - (2026-02-28)
+# ver. 1.3.8 - (2026-03-01)
 
 Frosted Glass:
   modes:
@@ -51,8 +51,8 @@ Frosted Glass:
           position: absolute;
           inset: 0;
           background: var(--ha-card-glass-tint, rgba(255, 255, 255, 0.08));                                    /* 1.2 Glass – subtle tint */
-          backdrop-filter: var(--ha-card-backdrop-filter, blur(8px) saturate(1.2));
-          -webkit-backdrop-filter: var(--ha-card-backdrop-filter, blur(8px) saturate(1.2));
+          backdrop-filter: var(--ha-card-backdrop-filter, blur(8px) saturate(1.2) contrast(0.4));
+          -webkit-backdrop-filter: var(--ha-card-backdrop-filter, blur(8px) saturate(1.2) contrast(0.4));
           z-index: -1;
           pointer-events: none;
           border-radius: inherit;
@@ -64,15 +64,13 @@ Frosted Glass:
           );
         }
 
-        /* Headings + Glance (kept as your exclusions) */
-        :host(hui-heading-card) ha-card,
-        :host(hui-glance-card) ha-card {
+        /* Headings (kept excluded) */
+        :host(hui-heading-card) ha-card {
           background: none !important;
           backdrop-filter: none !important;
           -webkit-backdrop-filter: none !important;
         }
-        :host(hui-heading-card) ha-card::before,
-        :host(hui-glance-card) ha-card::before {
+        :host(hui-heading-card) ha-card::before {
           content: none !important;
         }
 
@@ -143,6 +141,18 @@ Frosted Glass:
           -webkit-backdrop-filter: none !important;
         }
 
+        /* === Prevent frosted/glass from applying to streamline-card wrapper === */
+        :host(.type-custom-streamline-card) ha-card {
+          background: none !important;
+          backdrop-filter: none !important;
+          -webkit-backdrop-filter: none !important;
+          box-shadow: none !important;
+          border-radius: 0px !important;
+        }
+        :host(.type-custom-streamline-card) ha-card::before {
+          content: none !important;
+        }
+
       # =========================
       # CARD-MOD-ROOT GLOBAL CSS
       # =========================
@@ -152,7 +162,7 @@ Frosted Glass:
         --ha-card-box-shadow: 0 12px 20px rgba(0, 0, 0, 0.15);
         --ha-card-border-width: 0.5px;
         --ha-card-border-color: rgba(255, 255, 255, 0.3);
-        --ha-card-backdrop-filter: blur(8px) saturate(1.2);
+        --ha-card-backdrop-filter: blur(8px) saturate(1.2) contrast(0.4);
 
         /* Glass system tokens */
         --ha-card-glass-tint: rgba(255, 255, 255, 0.08);
@@ -327,6 +337,15 @@ Frosted Glass:
         }
 
       # =========================
+      # CARD-MOD-VIEW (edit-mode empty card fix)
+      # =========================
+      card-mod-view-yaml: |
+        hui-sections-view $ hui-grid-section $ hui-card-edit-mode $: |
+          .card-wrapper {
+            min-height: var(--row-height);
+          }
+
+      # =========================
       # TYPOGRAPHY
       # =========================
       ha-font-family-body: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"'
@@ -433,7 +452,7 @@ Frosted Glass:
       secondary-background-color: 'rgba(245, 245, 245, 0.5)'
       clear-background-color: 'rgba(254, 244, 242, 0.9)'
       card-background-color: 'rgba(254, 244, 242, 0.9)'
-      ha-card-background: 'rgba(254, 244, 242, 0.9)'
+      ha-card-background: 'rgba(254, 244, 242, 0.4)'
       ha-card-border-radius: '18px'
       ha-card-border-color: 'rgba(255, 255, 255, 0.3)'
       ha-card-border-width: '0.5px'
@@ -518,7 +537,7 @@ Frosted Glass:
       # =========================
       # DIALOGS
       # =========================
-      ha-dialog-surface-background: 'rgba(30, 30, 30, 0.92)'
+      ha-dialog-surface-background: 'rgba(30, 30, 30, 0.97)'
       dialog-box-shadow: '0 12px 20px rgba(0, 0, 0, 0.25)'
       paper-dialog-background-color: 'rgba(30, 30, 30, 0.7)'
       mdc-dialog-scrim-color: 'rgba(0, 0, 0, 0.8)'
@@ -540,8 +559,8 @@ Frosted Glass:
           position: absolute;
           inset: 0;
           background: var(--ha-card-glass-tint, rgba(28, 29, 33, 0.18));                    /* 1.2 Glass – subtle dark tint */
-          backdrop-filter: var(--ha-card-backdrop-filter, blur(10px) saturate(1.2));
-          -webkit-backdrop-filter: var(--ha-card-backdrop-filter, blur(10px) saturate(1.2));
+          backdrop-filter: var(--ha-card-backdrop-filter, blur(10px) saturate(1.2) contrast(0.4));
+          -webkit-backdrop-filter: var(--ha-card-backdrop-filter, blur(10px) saturate(1.2) contrast(0.4));
           z-index: -1;
           pointer-events: none;
           border-radius: inherit;
@@ -553,15 +572,13 @@ Frosted Glass:
           );
         }
 
-        /* Headings + Glance (kept excluded) */
-        :host(hui-heading-card) ha-card,
-        :host(hui-glance-card) ha-card {
+        /* Headings (kept excluded) */
+        :host(hui-heading-card) ha-card {
           background: none !important;
           backdrop-filter: none !important;
           -webkit-backdrop-filter: none !important;
         }
-        :host(hui-heading-card) ha-card::before,
-        :host(hui-glance-card) ha-card::before {
+        :host(hui-heading-card) ha-card::before {
           content: none !important;
         }
 
@@ -631,7 +648,17 @@ Frosted Glass:
           -webkit-backdrop-filter: none !important;
         }
 
-        /* (Removed) .bubble-button-card-container styling to avoid conflicts               # 1.2 Glass – matches Light exclusions */
+        /* === Prevent frosted/glass from applying to streamline-card wrapper === */
+        :host(.type-custom-streamline-card) ha-card {
+          background: none !important;
+          backdrop-filter: none !important;
+          -webkit-backdrop-filter: none !important;
+          box-shadow: none !important;
+          border-radius: 0px !important;
+        }
+        :host(.type-custom-streamline-card) ha-card::before {
+          content: none !important;
+        }
 
       # =========================
       # CARD-MOD-ROOT GLOBAL CSS
@@ -642,7 +669,7 @@ Frosted Glass:
           --ha-card-box-shadow: 0 12px 20px rgba(0, 0, 0, 0.28);
           --ha-card-border-width: 0.5px;
           --ha-card-border-color: rgba(234, 235, 238, 0.1);
-          --ha-card-backdrop-filter: blur(10px) saturate(1.2);
+          --ha-card-backdrop-filter: blur(10px) saturate(1.2) contrast(0.4);
 
           /* Glass system tokens (dark-tuned) */
           --ha-card-glass-tint: rgba(28, 29, 33, 0.18);
@@ -832,6 +859,15 @@ Frosted Glass:
         }
 
       # =========================
+      # CARD-MOD-VIEW (edit-mode empty card fix)
+      # =========================
+      card-mod-view-yaml: |
+        hui-sections-view $ hui-grid-section $ hui-card-edit-mode $: |
+          .card-wrapper {
+            min-height: var(--row-height);
+          }
+
+      # =========================
       # TYPOGRAPHY
       # =========================
       ha-font-family-body: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"'
@@ -937,7 +973,7 @@ Frosted Glass:
       secondary-background-color: 'rgba(30, 33, 54, 0.6)'
       clear-background-color: 'rgba(30, 33, 54, 0.7)'
       card-background-color: 'rgba(30, 30, 30, 0.85)'
-      ha-card-background: 'rgba(30, 30, 30, 0.9)'
+      ha-card-background: 'rgba(30, 30, 30, 0.4)'
       ha-card-border-radius: '18px'
       ha-card-border-color: 'rgba(234, 235, 238, 0.22)'
       ha-card-border-width: '0.5px'
@@ -946,6 +982,9 @@ Frosted Glass:
       ha-card-box-shadow: '0 12px 20px rgba(0, 0, 0, 0.28)'
       ha-view-sections-column-gap: '17px'
       ha-view-sections-column-min-width: 320px
+
+      # Control buttons
+      control-button-background-color: 'rgba(173, 176, 184, 0.2)'
 
       # Sliders, toggles, switches
       paper-slider-knob-color: 'rgb(106, 116, 211)'

--- a/themes/Frosted Glass.yaml
+++ b/themes/Frosted Glass.yaml
@@ -1,5 +1,5 @@
 # Frosted Glass
-# ver. 1.3.8 - (2026-03-01)
+# ver. 1.3.9 - (2026-03-01)
 
 Frosted Glass:
   modes:
@@ -51,8 +51,8 @@ Frosted Glass:
           position: absolute;
           inset: 0;
           background: var(--ha-card-glass-tint, rgba(255, 255, 255, 0.08));                                    /* 1.2 Glass – subtle tint */
-          backdrop-filter: var(--ha-card-backdrop-filter, blur(8px) saturate(1.2) contrast(0.4));
-          -webkit-backdrop-filter: var(--ha-card-backdrop-filter, blur(8px) saturate(1.2) contrast(0.4));
+          backdrop-filter: var(--ha-card-backdrop-filter, blur(8px) saturate(1.2));
+          -webkit-backdrop-filter: var(--ha-card-backdrop-filter, blur(8px) saturate(1.2));
           z-index: -1;
           pointer-events: none;
           border-radius: inherit;
@@ -162,7 +162,7 @@ Frosted Glass:
         --ha-card-box-shadow: 0 12px 20px rgba(0, 0, 0, 0.15);
         --ha-card-border-width: 0.5px;
         --ha-card-border-color: rgba(255, 255, 255, 0.3);
-        --ha-card-backdrop-filter: blur(8px) saturate(1.2) contrast(0.4);
+        --ha-card-backdrop-filter: blur(8px) saturate(1.2);
 
         /* Glass system tokens */
         --ha-card-glass-tint: rgba(255, 255, 255, 0.08);
@@ -452,7 +452,7 @@ Frosted Glass:
       secondary-background-color: 'rgba(245, 245, 245, 0.5)'
       clear-background-color: 'rgba(254, 244, 242, 0.9)'
       card-background-color: 'rgba(254, 244, 242, 0.9)'
-      ha-card-background: 'rgba(254, 244, 242, 0.4)'
+      ha-card-background: 'rgba(254, 244, 242, 0.9)'
       ha-card-border-radius: '18px'
       ha-card-border-color: 'rgba(255, 255, 255, 0.3)'
       ha-card-border-width: '0.5px'
@@ -559,8 +559,8 @@ Frosted Glass:
           position: absolute;
           inset: 0;
           background: var(--ha-card-glass-tint, rgba(28, 29, 33, 0.18));                    /* 1.2 Glass – subtle dark tint */
-          backdrop-filter: var(--ha-card-backdrop-filter, blur(10px) saturate(1.2) contrast(0.4));
-          -webkit-backdrop-filter: var(--ha-card-backdrop-filter, blur(10px) saturate(1.2) contrast(0.4));
+          backdrop-filter: var(--ha-card-backdrop-filter, blur(10px) saturate(1.2));
+          -webkit-backdrop-filter: var(--ha-card-backdrop-filter, blur(10px) saturate(1.2));
           z-index: -1;
           pointer-events: none;
           border-radius: inherit;
@@ -669,7 +669,7 @@ Frosted Glass:
           --ha-card-box-shadow: 0 12px 20px rgba(0, 0, 0, 0.28);
           --ha-card-border-width: 0.5px;
           --ha-card-border-color: rgba(234, 235, 238, 0.1);
-          --ha-card-backdrop-filter: blur(10px) saturate(1.2) contrast(0.4);
+          --ha-card-backdrop-filter: blur(10px) saturate(1.2);
 
           /* Glass system tokens (dark-tuned) */
           --ha-card-glass-tint: rgba(28, 29, 33, 0.18);
@@ -973,7 +973,7 @@ Frosted Glass:
       secondary-background-color: 'rgba(30, 33, 54, 0.6)'
       clear-background-color: 'rgba(30, 33, 54, 0.7)'
       card-background-color: 'rgba(30, 30, 30, 0.85)'
-      ha-card-background: 'rgba(30, 30, 30, 0.4)'
+      ha-card-background: 'rgba(30, 30, 30, 0.9)'
       ha-card-border-radius: '18px'
       ha-card-border-color: 'rgba(234, 235, 238, 0.22)'
       ha-card-border-width: '0.5px'


### PR DESCRIPTION
## Summary

- **Restored frosted glass blur on the dark mode header** using a `::before` pseudo-element technique
- **Dropdowns work correctly** even with the header blur active
- **Fixed 5 upstream issues**: dialog readability, glance card exclusion, streamline-card compatibility, empty card editing, dark mode button color

## Header Fix

Applying `backdrop-filter: blur()` directly to `.header` creates a CSS containing block, which breaks all `position: fixed` dropdowns inside it (issues #42, #71, #83, #89, #91, #100, #109, #112, #114, #118, #120, #121).

Instead of applying `backdrop-filter` to `.header` itself, it's now applied to `.header::before` via `card-mod-root`. Since `::before` has no DOM children, the containing block it creates affects nothing — dropdowns position correctly.

## Upstream Issue Fixes

### #123 — Dialog transparency/readability (dark mode)
Increased `ha-dialog-surface-background` opacity from `0.92` to `0.97` so background text doesn't bleed through dialogs.

### #102 — Glance card excluded from glass effect
Removed the forced `:host(hui-glance-card)` exclusion from `card-mod-card` so glance cards now get the frosted glass styling.

### #107 — Bubble card broken with streamline-card templates
Added streamline-card exclusion to prevent glass effect misalignment when bubble cards are rendered via `streamline-card`.

### #110 — Can't edit/see empty cards since 2025.11
Added `card-mod-view-yaml` with `min-height: var(--row-height)` for `.card-wrapper` in edit mode.

### #90 — Button color barely visible (dark mode)
Added explicit `control-button-background-color: rgba(173, 176, 184, 0.2)` to dark mode themes.

## Files Changed

All 6 theme files updated. Version bumped to 1.3.9.

## Test plan

- [x] Frosted glass blur visible on header in dark mode
- [x] Dropdown menus position correctly
- [x] Mushroom cards retain frosted glass transparency
- [x] Cards render glass effect correctly
- [x] Dialogs are readable in dark mode
- [x] Empty cards can be selected in edit mode
- [x] Glance cards show glass styling
- [ ] Streamline-card + bubble card renders correctly
- [x] Dark mode button colors are visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)